### PR TITLE
Ny testregel nett-1.4.12a på 1.4.12 er klar for kvalitetssikering

### DIFF
--- a/Testreglar/nett-1.4.12a.json
+++ b/Testreglar/nett-1.4.12a.json
@@ -30,7 +30,7 @@
 	"steg": [
 		{
 			"stegnr": "2.1",
-			"spm": "Hvilken side tester du på?",
+			"spm": "Hva side tester du på?",
 			"ht": "<p>Oppgi URL eller side-ID.</p>",
 			"type": "tekst",
 			"kilde": [],
@@ -80,7 +80,7 @@
 		{
 			"stegnr": "2.4",
 			"spm": "Støtter teksten endring av tekstegenskaper?",
-			"ht": "<p>Tekstegenskaper i dette kravet omfatter linjehøyde (linjeavstand), avstand etter avsnitt, avstanden mellom bokstaver i blokker av tekst (sperring) og avstanden mellom ord.</p>\n<p><strong>Unntak: </strong>Menneskelige språk eller skripter som ikke bruker en eller flere av disse tekstegenskapene i skriftspråket er et unntak i kravet. Etter ordlyden er det tilstrekkelig å kun bruke tekstegenskapene som finnes for den bestemte kombinasjonen av språk og skript. Eksempler på tekst som er unntatt, fordi den ikke støtter endring av tekstegenskaper, er</p>\n<ul>\n<li>video med innbrent (fast) teksting</li>\n<li>PDF-dokumenter</li>\n<li>bilder av tekst: i relasjon til dette suksesskriteriet er implementasjoner av canvas å regne som bilder av tekst</li>\n</ul>",
+			"ht": "<p>Tekstegenskaper i dette kravet omfatter linjehøyde (linjeavstand), avstand etter avsnitt, avstanden mellom bokstaver i blokker av tekst (sperring) og avstanden mellom ord.</p>\n<p><strong>Retningslinje for test:</strong></p>\n<ul>\n<li>For å teste om teksten på side støtter endring av tekstegenskaper, bruk verktøy Text Spacing. Slik bruker du verktøyet:\n<ul>\n<li>Dra lenken med verktøyet <a href=\"javascript:(function(){var d=document,id='phltsbkmklt',el=d.getElementById(id),f=d.querySelectorAll('iframe'),i=0,l=f.length;if(el){function removeFromShadows(root){for(var el of root.querySelectorAll('*')){if(el.shadowRoot){el.shadowRoot.getElementById(id).remove();removeFromShadows(el.shadowRoot);}}}el.remove();if(l){for(i=0;i<l;i++){try{f[i].contentWindow.document.getElementById(id).remove();removeFromShadows(f[i].contentWindow.document);}catch(e){console.log(e)}}}removeFromShadows(d);}else{s=d.createElement('style');s.id=id;s.appendChild(d.createTextNode('*{line-height:1.5 !important;letter-spacing:0.12em !important;word-spacing:0.16em !important;}p{margin-bottom:2em !important;}'));function applyToShadows(root){for(var el of root.querySelectorAll('*')){if(el.shadowRoot){el.shadowRoot.appendChild(s.cloneNode(true));applyToShadows(el.shadowRoot);}}}d.getElementsByTagName('head')[0].appendChild(s);for(i=0;i<l;i++){try{f[i].contentWindow.document.getElementsByTagName('head')[0].appendChild(s.cloneNode(true));applyToShadows(f[i].contentWindow.document);}catch(e){console.log(e)}}applyToShadows(d);}})();\">Text Spacing</a> til bokmerkeraden i nettleseren.</li>\n<li>Bruk verktøyet på teste testsiden.</li>\n</ul>\n</li>\n<li>Hvis du ser endringer i linjehøyde (linjeavstand), avstand etter avsnitt, avstanden mellom bokstaver i blokker av tekst (sperring) og avstanden mellom ord på siden, da betyr det at teksten støtter endring av tekstegenskaper.</li>\n</ul>\n<p><strong>Teknisk forklaring:</strong></p>\n<p>Dette verktøyet endrer følgende egenskaper som faktisk kreves for å teste dette kravet.</p>\n<p><code>* {</code><br><code>        line-height: 1.5 !important;</code><br><code>        letter-spacing: 0.12em !important;</code><br><code>        word-spacing: 0.16em !important;</code><br><code>        }</code><br><code>        p {</code><br><code>        margin-bottom: 2em !important;</code><br><code>   }</code></p>\n<p><strong>Unntak: </strong>Menneskelige språk eller skripter som ikke bruker en eller flere av disse tekstegenskapene i skriftspråket er et unntak i kravet. Etter ordlyden er det tilstrekkelig å kun bruke tekstegenskapene som finnes for den bestemte kombinasjonen av språk og skript. Eksempler på tekst som er unntatt, fordi den ikke støtter endring av tekstegenskaper, er</p>\n<ul>\n<li>video med innbrent (fast) teksting</li>\n<li>PDF-dokumenter</li>\n<li>bilder av tekst: i relasjon til dette suksesskriteriet er implementasjoner av canvas å regne som bilder av tekst</li>\n</ul>",
 			"type": "jaNei",
 			"kilde": [],
 			"ruting": {
@@ -161,7 +161,7 @@
 		{
 			"stegnr": "3.4",
 			"spm": "Blir andre stilegenskaper, enn de som inngår i kravet, endret som følge av justert tekstavstand?",
-			"ht": "<p>Sjekk at andre stilegenskaper ikke blir endret som følge av justert tekstavstand.</p>\n<p>Andre stilegenskaper er for eksempel endret skrifttype, farge, størrelse, plassering, avstand rundt elements innhold (padding), volum, prosodi i den syntetiske talen av innholdselementet som de er gjengitt (for eksempel på skjerm, via høyttaler, via leselist) av brukeragenter.</p>",
+			"ht": "<p>Sjekk at andre stilegenskaper ikke blir endret som følge av justert tekstavstand.</p>\n<p>Endring i andre stilegenskaper er for eksempel endret skrifttype, farge, størrelse, plassering, avstand rundt elements innhold (padding), volum, prosodi i den syntetiske talen av innholdselementet som de er gjengitt (for eksempel på skjerm, via høyttaler, via leselist) av brukeragenter.</p>",
 			"type": "jaNei",
 			"kilde": [],
 			"ruting": {


### PR DESCRIPTION
Testregel på 1.4.12 Tekstavstand for nettsider, lager ikke flere testregler på apper og dokumenter, fordi basert på forståartikkelen gjelder kravet kunne løsninger som er utviklet ved bruk av oppmerkingsspråk.