### PR TITLE
nett-4.1.2a er klar for ks

### DIFF
--- a/Testreglar/4.1.2/Nett/nett-4.1.2a.json
+++ b/Testreglar/4.1.2/Nett/nett-4.1.2a.json
@@ -5,7 +5,7 @@
 	"versjon": "1.0",
 	"type": "Nett",
 	"spraak": "nb",
-	"kravTilSamsvar": "<p>Det er flere måter å oppfylle kravet på.</p>\r\n<p>Navn og rolle:</p>\r\n<ul>\r\n<li>Alle skjemaelementer har et tilgjengelig navn, som beskriver formålet med det aktuelle elementet og </li>\r\n<li>Skjemaelementer som tilhører en gruppe, er også koblet til et tilgjengelig navn som gjelder for gruppen og</li>\r\n<li>Alle skjemaelementer har riktig rolle, som identifiserer funksjonen til det aktuelle elementet</li>\r\n</ul>\r\n<p>Tilstander, egenskaper og verdier:</p>\r\n<ul>\r\n<li>Når tilstander, egenskaper og verdier i skjemaelementer kan angis av brukeren, skal denne informasjonen også angis programmatisk og</li>\r\n<li>Varsel om endringer i den aktuelle elementet er tilgjengelig for brukeragenter </li>\r\n</ul>\r\n<p> </p>",
+	"kravTilSamsvar": "<p>Det er flere måter å oppfylle kravet på.</p>\r\n<p>Navn og rolle:</p>\r\n<ul>\r\n<li>Alle skjemaelementer har et tilgjengelig navn, som beskriver formålet med det aktuelle elementet og </li>\r\n<li>Alle skjemaelementer har riktig rolle, som identifiserer funksjonen til det aktuelle elementet og</li>\r\n<li>Skjemaelementer som tilhører en gruppe, er også koblet til et tilgjengelig navn som gjelder for gruppen</li>\r\n</ul>\r\n<p>Tilstander, egenskaper og verdier:</p>\r\n<ul>\r\n<li>Når tilstander, egenskaper og verdier i skjemaelementer kan angis av brukeren, skal denne informasjonen også angis programmatisk og</li>\r\n<li>Varsel om endringer i den aktuelle elementet er tilgjengelig for brukeragenter </li>\r\n</ul>\r\n<p> </p>",
 	"side": "2.1",
 	"element": "3.1",
 	"kolonner": [
@@ -84,7 +84,7 @@
 		},
 		{
 			"stegnr": "2.2",
-			"spm": "Bruk verktøyet og sjekk om det gir resultater under \"Form control has accessible name\".",
+			"spm": "Gir verktøyet resultater under \"Form control has accessible name\"?",
 			"ht": "<p>Slik tester du:</p>\n<ul>\n<li>Bruk verktøyet <a href=\"https://chrome.google.com/webstore/detail/qualweb-extension/ljgilomdnehokancdcbkmbndkkiggioc\" target=\"_blank\" rel=\"noopener\">QualWeb </a>i Chrome på testsiden\n<ul>\n<li>velg kun \"ACT Rules\"</li>\n<li>trykk på knappen \"Evaluate\"</li>\n<li>utvid \"Fliters\"</li>\n<li>fjern hake på \"Warning\"</li>\n</ul>\n</li>\n<li>Sjekk om det finnes resultater på \"Form control has accessible name\"<br>\n<ul>\n<li>trykk på \"Form control has accessible name\" for å vise aktuelle resultater\n<ul>\n<li>Dersom alternativene ikke kommer opp, har ikke QW funnet skjemaelementer</li>\n</ul>\n</li>\n<li>velg både Passed og Failed</li>\n<li>du kan bruke \"Highlight Element\" for å vise hvor aktuelle elementer ligger på siden\n<ul>\n<li>Bruk pilene for å navigere gjennom resultater for forskjellige elementer</li>\n</ul>\n</li>\n</ul>\n</li>\n</ul>\n<p><strong>Merk:</strong></p>\n<ul>\n<li><strong>Du skal ikke teste knapper. Knapper har egen testregel.</strong> \n<ul>\n<li>Knapper blir  for eksempel brukt til å aktivere en funksjon eller sende inn skjema. </li>\n</ul>\n</li>\n<li>Du skal teste både aktive og inaktive skjemaelementer.</li>\n<li>Hvis verktøyet ikke finner skjemaelementer, velger du \"Nei\" i dette steget</li>\n</ul>",
 			"type": "jaNei",
 			"ruting": {
@@ -114,20 +114,24 @@
 		},
 		{
 			"stegnr": "3.2",
-			"spm": "Har verktøyet funnet brudd for dette skjemaelementet?",
-			"ht": "<p>Hvis Qualweb gir resultat:</p>\n<ul>\n<li>\"Failed\": Det er brudd og testen avsluttes.</li>\n<li>\"Passed\": Skjemaelementet skal testes videre.</li>\n</ul>",
-			"type": "jaNei",
+			"spm": "Hvilket resultat gir verktøyet for dette skjemaelementet?",
+			"ht": "<p>Verktøyet gir resultat:</p>",
+			"type": "radio",
 			"ruting": {
-				"ja": {
+				"alt0": {
 					"type": "avslutt",
 					"fasit": "Nei",
 					"utfall": "Skjemaelementet har ikke et tilgjengelig navn."
 				},
-				"nei": {
+				"alt1": {
 					"type": "gaaTil",
 					"steg": "3.3"
 				}
-			}
+			},
+			"svarArray": [
+				"Brudd (Failed)",
+				"Samsvar (Passed)"
+			]
 		},
 		{
 			"stegnr": "3.3",

--- a/Testreglar/4.1.2/Nett/nett-4.1.2a.json
+++ b/Testreglar/4.1.2/Nett/nett-4.1.2a.json
@@ -5,7 +5,7 @@
 	"versjon": "1.0",
 	"type": "Nett",
 	"spraak": "nb",
-	"kravTilSamsvar": "<p>Det er flere måter å oppfylle kravet på.</p>\r\n<p>Navn og rolle:</p>\r\n<ul>\r\n<li>Alle skjemaelementer har et tilgjengelig navn, som beskriver formålet med det aktuelle elementet og </li>\r\n<li>Alle skjemaelementer har riktig rolle, som identifiserer funksjonen til det aktuelle elementet og</li>\r\n<li>Skjemaelementer som tilhører en gruppe, er også koblet til et tilgjengelig navn som gjelder for gruppen</li>\r\n</ul>\r\n<p>Tilstander, egenskaper og verdier:</p>\r\n<ul>\r\n<li>Når tilstander, egenskaper og verdier i skjemaelementer kan angis av brukeren, skal denne informasjonen også angis programmatisk og</li>\r\n<li>Varsel om endringer i den aktuelle elementet er tilgjengelig for brukeragenter </li>\r\n</ul>\r\n<p> </p>",
+	"kravTilSamsvar": "<p>Det er flere måter å oppfylle kravet på.</p>\r\n<p>Navn og rolle:</p>\r\n<ul>\r\n<li>Alle skjemaelementer har et tilgjengelig navn, som beskriver formålet med det aktuelle elementet og </li>\r\n<li>Alle skjemaelementer har riktig rolle, som identifiserer funksjonen til det aktuelle elementet og</li>\r\n<li>Skjemaelementer som tilhører en gruppe, er også koblet til et tilgjengelig navn som gjelder for gruppen</li>\r\n</ul>\r\n<p>Tilstander, egenskaper og verdier:</p>\r\n<ul>\r\n<li>Når tilstander, egenskaper og verdier i skjemaelementer kan angis av brukeren, skal denne informasjonen også angis programmatisk og</li>\r\n<li>Varsel om endringer i det aktuelle elementet er tilgjengelig for brukeragenter</li>\r\n</ul>",
 	"side": "2.1",
 	"element": "3.1",
 	"kolonner": [
@@ -65,6 +65,9 @@
 		},
 		{
 			"title": "3.19"
+		},
+		{
+			"title": "3.20"
 		}
 	],
 	"steg": [
@@ -94,7 +97,7 @@
 				},
 				"nei": {
 					"type": "gaaTil",
-					"steg": "3.19"
+					"steg": "3.20"
 				}
 			}
 		},
@@ -397,8 +400,8 @@
 		},
 		{
 			"stegnr": "3.17",
-			"spm": "Hvilken tilstand tester du?",
-			"ht": "<p>Beskriv tilstanden, slik at det er mulig å identifisere den i ettertid.</p>",
+			"spm": "Hvor mange tilstander har skjemaelementet? ",
+			"ht": "<p>Registrer antall tilstander.</p>\n<p>Eksempel: En avkryssingsboks kan ha to tilstander, avkrysset eller ikke avkrysset.</p>",
 			"type": "tekst",
 			"ruting": {
 				"alle": {
@@ -406,33 +409,64 @@
 					"steg": "3.18"
 				}
 			},
-			"label": "Tilstand:",
-			"multilinje": true
+			"label": "Antall tilstander:",
+			"filter": "tal"
 		},
 		{
 			"stegnr": "3.18",
-			"spm": "Er den aktuelle tilstanden angitt programmatisk?",
-			"ht": "<p>Slik tester du:</p>\n<ul>\n<li>Inspiser skjemaelementet i Chrome</li>\n<li>Bruk Accessibility Checker</li>\n<li>Under ARIA-attributter eller Computed Properties, sjekk om det finnes:\n<ul>\n<li>avkryssingsboks eller radioknapp\n<ul>\n<li>hvis avkrysset: aria-checked: true eller Checked: true</li>\n<li>hvis ikke avkrysset: aria-checked: false eller Checked: false</li>\n</ul>\n</li>\n<li>nedtrekksliste<br>\n<ul>\n<li>hvis innholdet er sammensluttet: aria-expanded: false eller Expanded: false</li>\n<li>hvis innholdet er utvidet: aria-expanded: true eller Expanded: true</li>\n</ul>\n</li>\n<li>switch\n<ul>\n<li>hvis knappen er på: aria-pressed: true eller aria-checked: true</li>\n<li>hvis knappen er av: aria-pressed: false eller aria-checked: false</li>\n<li>hvis knappen har en mellomliggende tilstand mellom tilstander av og på: aria-pressed: mixed.</li>\n</ul>\n</li>\n<li>annet: andre relevante tilstander (State) knyttet til <a href=\"https://www.w3.org/TR/wai-aria-1.2/#widget_roles\" target=\"_blank\" rel=\"noopener\">Widget Roles</a></li>\n</ul>\n</li>\n</ul>",
-			"type": "jaNei",
+			"spm": "Hvor mange tilstander er ikke angitt programmatisk?",
+			"ht": "<p>Slik tester du:</p>\n<ul>\n<li>Inspiser skjemaelementet i Chrome</li>\n<li>Bruk Accessibility Checker</li>\n<li>Under ARIA-attributter eller Computed Properties, sjekk om det finnes:\n<ul>\n<li>avkryssingsboks eller radioknapp\n<ul>\n<li>hvis avkrysset: aria-checked: true eller Checked: true</li>\n<li>hvis ikke avkrysset: aria-checked: false eller Checked: false</li>\n</ul>\n</li>\n<li>nedtrekksliste<br>\n<ul>\n<li>hvis innholdet er sammensluttet: aria-expanded: false eller Expanded: false</li>\n<li>hvis innholdet er utvidet: aria-expanded: true eller Expanded: true</li>\n</ul>\n</li>\n<li>switch\n<ul>\n<li>hvis knappen er på: aria-pressed: true eller aria-checked: true</li>\n<li>hvis knappen er av: aria-pressed: false eller aria-checked: false</li>\n<li>hvis knappen har en mellomliggende tilstand mellom tilstander av og på: aria-pressed: mixed.</li>\n</ul>\n</li>\n<li>annet: andre relevante tilstander (State) knyttet til <a href=\"https://www.w3.org/TR/wai-aria-1.2/#widget_roles\" target=\"_blank\" rel=\"noopener\">Widget Roles</a></li>\n</ul>\n</li>\n<li>Registrer antall tilstander som ikke er angitt programmatisk.</li>\n</ul>",
+			"type": "tekst",
 			"ruting": {
-				"ja": {
-					"type": "avslutt",
-					"fasit": "Ja",
-					"utfall": "Skjemaelementet har et tilgjengelig navn, og riktig rolle, som beskriver formålet med det aktuelle elementet. Tilstanden er angitt programmatisk."
-				},
-				"nei": {
-					"type": "avslutt",
-					"fasit": "Nei",
-					"utfall": "Skjemaelementet har et tilgjengelig navn, og riktig rolle, som beskriver formålet med det aktuelle elementet. Tilstanden er ikke angitt programmatisk."
+				"alle": {
+					"type": "regler",
+					"regler": {
+						"1": {
+							"type": "lik",
+							"sjekk": "3.18",
+							"verdi": "0",
+							"handling": {
+								"type": "avslutt",
+								"fasit": "Ja",
+								"utfall": "Skjemaelementet har et tilgjengelig navn, og riktig rolle, som beskriver formålet med det aktuelle elementet. Tilstanden er angitt programmatisk."
+							}
+						},
+						"2": {
+							"type": "ulik",
+							"sjekk": "3.18",
+							"verdi": "0",
+							"handling": {
+								"type": "gaaTil",
+								"steg": "3.19"
+							}
+						}
+					}
 				}
 			},
 			"kilde": [
 				"ARIA5",
 				"G10"
-			]
+			],
+			"label": "Antall tilstander:",
+			"filter": "tal"
 		},
 		{
 			"stegnr": "3.19",
+			"spm": "Hvilke tilstander er ikke angitt programmatisk?",
+			"ht": "<p>Beskriv tilstander som ikke er angitt programmatisk, slik at det er mulig å identifisere dem i ettertid.</p>",
+			"type": "tekst",
+			"ruting": {
+				"alle": {
+					"type": "avslutt",
+					"fasit": "Nei",
+					"utfall": "Skjemaelementet har et tilgjengelig navn, og riktig rolle, som beskriver formålet med det aktuelle elementet. Tilstanden er ikke angitt programmatisk."
+				}
+			},
+			"label": "Tilstander:",
+			"multilinje": true
+		},
+		{
+			"stegnr": "3.20",
 			"spm": "Har testsiden skjemaelementer som verktøyet ikke avdekker?",
 			"ht": "<p>Gjør en visuell inspeksjon og sjekk om det finnes flere skjemaelementer på testsiden.</p>\n<p>Begrensninger i verktøyet</p>\n<ul>\n<li>Det finner kun skjemaelementer som har en rolle fra <a href=\"https://www.w3.org/TR/wai-aria-1.2/#widget_roles\" target=\"_blank\" rel=\"noopener\">Widget Role</a></li>\n<li>Det finner ikke skjemaelementer kodet på andre måter, for eksempel <code>&lt;div&gt;</code>, <code>&lt;span&gt;</code> eller lignende  </li>\n</ul>\n<p><strong>Skjemaelement:</strong> Eksempel på skjemaelementer er avkryssningsboks, nedtrekksliste, radioknapp, inndatafelt, søkefelt, switch og listeboks.</p>",
 			"type": "jaNei",

--- a/Testreglar/4.1.2/Nett/nett-4.1.2a.json
+++ b/Testreglar/4.1.2/Nett/nett-4.1.2a.json
@@ -1,0 +1,487 @@
+{
+	"namn": "4.1.2a Skjemaelement er identifiserte i koden",
+	"id": "4.1.2a",
+	"testlabId": 245,
+	"versjon": "1.0",
+	"type": "Nett",
+	"spraak": "nn",
+	"kravTilSamsvar": "<p>Skjemaelement er kopla til ein ledetekst i koden. Dette kan gjerast på fleire måtar. Ledeteksten identifiserer skjemaelementet.</p>\r\n<p>Dersom skjemaelementet høyrer til ei gruppe, er det i tillegg kopla til ein ledetekst som gjeld for gruppa. Ledeteksten identifiserer gruppa.</p>",
+	"side": "2.1",
+	"element": "3.1",
+	"kolonner": [
+		{
+			"title": "2.2"
+		},
+		{
+			"title": "3.2"
+		},
+		{
+			"title": "3.3"
+		},
+		{
+			"title": "3.4"
+		},
+		{
+			"title": "3.5"
+		},
+		{
+			"title": "3.6"
+		},
+		{
+			"title": "3.7"
+		},
+		{
+			"title": "3.8"
+		},
+		{
+			"title": "3.9"
+		},
+		{
+			"title": "3.10"
+		},
+		{
+			"title": "3.11"
+		},
+		{
+			"title": "3.12"
+		},
+		{
+			"title": "3.13"
+		},
+		{
+			"title": "3.14"
+		},
+		{
+			"title": "3.15"
+		},
+		{
+			"title": "3.16"
+		},
+		{
+			"title": "3.17"
+		},
+		{
+			"title": "3.18"
+		},
+		{
+			"title": "3.19"
+		},
+		{
+			"title": "3.20"
+		}
+	],
+	"steg": [
+		{
+			"stegnr": "2.1",
+			"spm": "Kva side testar du på?",
+			"ht": "Oppgi url eller side-ID.",
+			"type": "tekst",
+			"label": "Url/Side:",
+			"datalist": "Sideutvalg",
+			"oblig": true,
+			"ruting": {
+				"alle": {
+					"type": "gaaTil",
+					"steg": "2.2"
+				}
+			}
+		},
+		{
+			"stegnr": "2.2",
+			"spm": "Har nettsida skjemaelement?",
+			"ht": "<p>Sjekk om nettsida har skjemaelement av type avkryssingsboks, radioknapp, tekstfelt eller nedtrekksliste.</p><p>Du skal teste både <strong>aktive</strong> og <strong>inaktive</strong> skjemaelement.</p><p><strong>Merk:</strong> Du skal ikkje teste knappar. Knappar blir brukt for eksempel til å aktivere ein funksjon eller sende inn skjema.</p>",
+			"type": "jaNei",
+			"ruting": {
+				"ja": {
+					"type": "gaaTil",
+					"steg": "3.1"
+				},
+				"nei": {
+					"type": "ikkjeForekomst",
+					"utfall": "Testside har ikkje skjema."
+				}
+			}
+		},
+		{
+			"stegnr": "3.1",
+			"spm": "Beskriv skjemaelementet som skal vurderast.",
+			"ht": "<p>Legg inn overskrift, eller andre stikkord som er slik at skjemaelementet kan identifiserast.</p>",
+			"type": "tekst",
+			"label": "Element",
+			"multilinje": true,
+			"oblig": true,
+			"ruting": {
+				"alle": {
+					"type": "gaaTil",
+					"steg": "3.2"
+				}
+			}
+		},
+		{
+			"stegnr": "3.2",
+			"spm": "Er skjemaelementet ein del av den globale søkefunksjonen?",
+			"ht": "Ein global søkefunksjon er ein navigasjonsmekanisme som let brukaren søke i alle sidene på nettstaden.",
+			"type": "jaNei",
+			"ruting": {
+				"alle": {
+					"type": "gaaTil",
+					"steg": "3.3"
+				}
+			}
+		},
+		{
+			"stegnr": "3.3",
+			"spm": "Korleis er skjemaelementet koda?",
+			"ht": "<p>Du kan bruke kodeverktøyet i nettlesaren for å sjekke dette. Skjemaelement er vanlegvis koda som <code>&#x3C;input&#x3E;</code> , <code>&#x3C;select&#x3E;</code> eller <code>&#x3C;textarea&#x3E;</code>.</p><strong>Merk:</strong> Du skal ikkje teste knappar.</p>",
+			"type": "radio",
+			"svarArray": [
+				"Input",
+				"Select",
+				"Textarea",
+				"Anna"
+			],
+			"ruting": {
+				"alle": {
+					"type": "gaaTil",
+					"steg": "3.4"
+				}
+			}
+		},
+		{
+			"stegnr": "3.4",
+			"spm": "Har skjemaelementet attributtet \"aria-label\" ?",
+			"ht": "<p>Sjå i koden og finn skjemaelementet.</p><p><strong>Merk:</strong> Du skal ikkje vurdere kvaliteten på teksten.</p>",
+			"type": "jaNei",
+			"kilde": [
+				"ARIA14"
+			],
+			"ruting": {
+				"ja": {
+					"type": "gaaTil",
+					"steg": "3.10"
+				},
+				"nei": {
+					"type": "gaaTil",
+					"steg": "3.5"
+				}
+			}
+		},
+		{
+			"stegnr": "3.5",
+			"spm": "Har skjemaelementet attributtet \"aria-labelledby\" ?",
+			"ht": "<p>Merk at ein aria-labelledby kan innhalde fleire id-ar i same attributt. Id-ane er skilt med mellomrom. (<code>Aria-labelledby=\"id1 id2\"</code>)</p><strong>Merk:</strong> Du skal ikkje vurdere kvaliteten på teksten. ",
+			"type": "jaNei",
+			"kilde": [
+				"ARIA16"
+			],
+			"ruting": {
+				"ja": {
+					"type": "gaaTil",
+					"steg": "3.6"
+				},
+				"nei": {
+					"type": "gaaTil",
+					"steg": "3.7"
+				}
+			}
+		},
+		{
+			"stegnr": "3.6",
+			"spm": "Er aria-labelledby attributtet kopla til annan tekst på sida (lenkekontekst)?",
+			"ht": "<p>Gjer eit søk i koden på id i aria-labelledby. Dersom det finst fleire id-ar, skal du undersøke alle. Id-ane vil då vere skilt med mellomrom. (<code>Aria-labelledby=\"id1 id2\"</code>).</p>",
+			"type": "jaNei",
+			"kilde": [
+				"ARIA16"
+			],
+			"ruting": {
+				"ja": {
+					"type": "gaaTil",
+					"steg": "3.10"
+				},
+				"nei": {
+					"type": "gaaTil",
+					"steg": "3.7"
+				}
+			}
+		},
+		{
+			"stegnr": "3.7",
+			"spm": "Er skjemaelementet kopla til eit &#x3C;label&#x3E;-element i koden?",
+			"ht": "<p>Du kan bruke kodeverktøyet i nettlesaren for å sjekke dette. Sjekk at:</p> <ol> <li> Skjemaelementet har eit id-attributt. </li> <li><code>&#x3C;label&#x3E;</code>-elementet har eit for-attributt.</li> <li>Innhaldet i <code>&#x3C;label&#x3E;</code>-elementet sitt for-attributt er det same som innhaldet i skjemaelementet sitt id-attributt.</li> </ol> <p>Det er nok at verdien er lik.</p> <p><strong>Merk:</strong> Det er ikkje tilstrekkeleg at svaralternativ i ei nedtrekksliste har label-attributt, fordi dette fungerer som identifikasjon til svaralternativet og ikkje til lista.</p>",
+			"type": "jaNei",
+			"kilde": [
+				"G108",
+				"H44",
+				"H91",
+				"F68",
+				"F86"
+			],
+			"ruting": {
+				"ja": {
+					"type": "gaaTil",
+					"steg": "3.10"
+				},
+				"nei": {
+					"type": "gaaTil",
+					"steg": "3.8"
+				}
+			}
+		},
+		{
+			"stegnr": "3.8",
+			"spm": "Ligg skjemaelementet inne i eit &#x3C;label&#x3E;-element i koden?",
+			"ht": "<p>Du kan bruke kodeverktøyet i nettlesaren for å sjekke dette. Sjå om det finst eit <code>&#x3C;label&#x3E;</code><-element som starter framføre og blir avslutta etter skjemaelementet. Du må kanskje felle ut <code>&#x3C;label&#x3E;</code>-elementet i koden for å sjå all koding.</p><p>I dette tilfellet er ledeteksten all tekst som ligg inne i <code>&#x3C;label&#x3E;</code>-elementet.</p>",
+			"type": "jaNei",
+			"kilde": [
+				"F68"
+			],
+			"ruting": {
+				"ja": {
+					"type": "gaaTil",
+					"steg": "3.10"
+				},
+				"nei": {
+					"type": "gaaTil",
+					"steg": "3.9"
+				}
+			}
+		},
+		{
+			"stegnr": "3.9",
+			"spm": "Har skjemaelementet eit title-attributt?",
+			"ht": "Du kan nytte kodeverktøyet i nettlesaren til å sjekke dette.",
+			"type": "jaNei",
+			"kilde": [
+				"G108",
+				"H65",
+				"H91",
+				"F68"
+			],
+			"ruting": {
+				"ja": {
+					"type": "gaaTil",
+					"steg": "3.10"
+				},
+				"nei": {
+					"type": "avslutt",
+					"fasit": "Nei",
+					"utfall": "Skjemaelement er ikkje er kopla til ein ledetekst i koden."
+				}
+			}
+		},
+		{
+			"stegnr": "3.10",
+			"spm": "Identifiserer ledeteksten skjemaelementet?",
+			"ht": "<p>Ta utgangspunktet i ledeteksten du fann i førre steg. Det er tilstrekkeleg at ledeteksten identifiserer skjemaelementet.</p><p><Strong>Merk:</strong> Ledeteksten skal vere på same språk som skjemaet.</p>",
+			"type": "jaNei",
+			"kilde": [
+				"G108"
+			],
+			"ruting": {
+				"ja": {
+					"type": "gaaTil",
+					"steg": "3.11"
+				},
+				"nei": {
+					"type": "avslutt",
+					"fasit": "Nei",
+					"utfall": "Skjemaelement er kopla til ein ledetekst i koden. Ledeteksten identifiserer ikkje skjemaelementet."
+				}
+			}
+		},
+		{
+			"stegnr": "3.11",
+			"spm": "Må skjemaelementet vere kopla til ein annan ledetekst/spørsmål for å gi meining?",
+			"ht": "<p>Eksempel på dette er grupper av radioknappar eller avkryssingsboksar som må lesast i samanheng med eit overordna spørsmål.</p><p>Ein tommelfingerregel er at når ei gruppe med skjemaelement krever ei egen overskrift, er det riktig å bruke fieldset og legend.</p> ",
+			"type": "jaNei",
+			"ruting": {
+				"ja": {
+					"type": "gaaTil",
+					"steg": "3.12"
+				},
+				"nei": {
+					"type": "avslutt",
+					"fasit": "Ja",
+					"utfall": "Skjemaelement er kopla til ein ledetekst i koden. Ledeteksten identifiserer skjemaelementet."
+				}
+			}
+		},
+		{
+			"stegnr": "3.12",
+			"spm": "Ligg skjemaelementet inne i eit &#x3C;fieldset&#x3E;-element?",
+			"ht": "Du kan bruke kodeverktøyet i nettlesaren for å sjekke dette.",
+			"type": "jaNei",
+			"kilde": [
+				"H71"
+			],
+			"ruting": {
+				"ja": {
+					"type": "gaaTil",
+					"steg": "3.13"
+				},
+				"nei": {
+					"type": "gaaTil",
+					"steg": "3.16"
+				}
+			}
+		},
+		{
+			"stegnr": "3.13",
+			"spm": "Ligg det eit &#x3C;legend&#x3E;-element inne i eit &#x3C;fieldset&#x3E;-elementet?",
+			"ht": "Du kan bruke kodeverktøyet i nettlesaren for å sjekke dette.",
+			"type": "jaNei",
+			"kilde": [
+				"H71"
+			],
+			"ruting": {
+				"ja": {
+					"type": "gaaTil",
+					"steg": "3.14"
+				},
+				"nei": {
+					"type": "gaaTil",
+					"steg": "3.16"
+				}
+			}
+		},
+		{
+			"stegnr": "3.14",
+			"spm": "Er &#x3C;legend&#x3E; det første elementet som ligg inne i &#x3C;fieldset&#x3E;?",
+			"ht": "Du kan bruke kodeverktøyet i nettlesaren for å sjekke dette.",
+			"type": "jaNei",
+			"kilde": [
+				"H71"
+			],
+			"ruting": {
+				"ja": {
+					"type": "gaaTil",
+					"steg": "3.15"
+				},
+				"nei": {
+					"type": "gaaTil",
+					"steg": "3.16"
+				}
+			}
+		},
+		{
+			"stegnr": "3.15",
+			"spm": "Blir skjemaelementet identifisert av innhaldet i &#x3C;legend&#x3E; saman med skjemaelementet sin ledetekst?",
+			"ht": "<p>Du skal vurdere samla både skjemaelementet sin ledetekst og innhaldet i <code>&#x3C;legend&#x3E;.</code></p>",
+			"type": "jaNei",
+			"kilde": [
+				"H71"
+			],
+			"ruting": {
+				"ja": {
+					"type": "avslutt",
+					"fasit": "Ja",
+					"utfall": "Skjemaelement er kopla til ein ledetekst i koden. Skjemaelement er plassert i ei gruppe i koden. Ledetekst identifiserer skjemaelementet."
+				},
+				"nei": {
+					"type": "gaaTil",
+					"steg": "3.16"
+				}
+			}
+		},
+		{
+			"stegnr": "3.16",
+			"spm": "Ligg skjemaelementet inne i eit anna element med attributtet role=\"group\"?",
+			"ht": "<p>Du kan bruke kodeverktøyet i nettlesaren for å sjekke dette.</p><p>Dette element som starter framføre og blir avslutta etter skjemaelementet du testar. Role-attributtet kan for eksempel ligge på ein <code>&#x3C;div&#x3E;</code> eller <code>&#x3C;span&#x3E;</code>.</p>",
+			"type": "jaNei",
+			"kilde": [
+				"ARIA17"
+			],
+			"ruting": {
+				"ja": {
+					"type": "gaaTil",
+					"steg": "3.17"
+				},
+				"nei": {
+					"type": "avslutt",
+					"fasit": "Nei",
+					"utfall": "Skjemaelement er kopla til ein ledetekst i koden. Skjemaelement er plassert i ei gruppe som ikkje er identifisert i koden."
+				}
+			}
+		},
+		{
+			"stegnr": "3.17",
+			"spm": "Har dette elementet attributtet \"aria-label\" ?",
+			"ht": "<p>Sjå i koden og finn skjemaelementet.</p><p><strong>Merk:</strong> Du skal ikkje vurdere kvaliteten på teksten. </p>",
+			"type": "jaNei",
+			"kilde": [
+				"ARIA17"
+			],
+			"ruting": {
+				"ja": {
+					"type": "gaaTil",
+					"steg": "3.20"
+				},
+				"nei": {
+					"type": "gaaTil",
+					"steg": "3.18"
+				}
+			}
+		},
+		{
+			"stegnr": "3.18",
+			"spm": "Har dette elementet attributtet \"aria-labelledby\" ?",
+			"ht": "<p>Merk at ein aria-labelledby kan innhalde fleire id-ar i same attributt. Id-ane er skilt med mellomrom. (<code>Aria-labelledby=\"id1 id2\"</code>)</p><p><strong>Merk:</strong> Du skal ikkje vurdere kvaliteten på teksten. </p>",
+			"type": "jaNei",
+			"kilde": [
+				"ARIA17"
+			],
+			"ruting": {
+				"ja": {
+					"type": "gaaTil",
+					"steg": "3.19"
+				},
+				"nei": {
+					"type": "avslutt",
+					"fasit": "Nei",
+					"utfall": "Skjemaelement er kopla til ein ledetekst i koden. Skjemaelement er plassert i ei gruppe som ikkje er identifisert i koden."
+				}
+			}
+		},
+		{
+			"stegnr": "3.19",
+			"spm": "Er aria-labelledby attributtet kopla til annan tekst på sida (lenkekontekst)?",
+			"ht": "<p>Gjer eit søk i koden på id i aria-labelledby. Dersom det finst fleire id-ar, skal du undersøke alle. Id-ane vil då vere skilt med mellomrom. (<code>Aria-labelledby=\"id1 id2\"</code>)</p>",
+			"type": "jaNei",
+			"kilde": [
+				"ARIA17"
+			],
+			"ruting": {
+				"ja": {
+					"type": "gaaTil",
+					"steg": "3.20"
+				},
+				"nei": {
+					"type": "avslutt",
+					"fasit": "Nei",
+					"utfall": "Skjemaelement er kopla til ein ledetekst i koden. Skjemaelement er plassert i ei gruppe som ikkje er identifisert i koden."
+				}
+			}
+		},
+		{
+			"stegnr": "3.20",
+			"spm": "Blir skjemaelementet identifisert av innhaldet i dette aria-attributtet saman med skjemaelementet sin ledetekst?",
+			"ht": "Du skal vurdere samla både skjemaelementet sin ledetekst og innhaldet i aria-attributtet til elementet som skjemaelementet ligg inne i.",
+			"type": "jaNei",
+			"kilde": [
+				"G108"
+			],
+			"ruting": {
+				"ja": {
+					"type": "avslutt",
+					"fasit": "Ja",
+					"utfall": "Skjemaelement er kopla til ein ledetekst i koden. Skjemaelement er plassert i ei gruppe i koden. Ledetekst identifiserer skjemaelementet."
+				},
+				"nei": {
+					"type": "avslutt",
+					"fasit": "Nei",
+					"utfall": "Skjemaelement er kopla til ein ledetekst i koden. Skjemaelement er plassert i ei gruppe som ikkje er identifisert i koden."
+				}
+			}
+		}
+	]
+}

--- a/Testreglar/4.1.2/Nett/nett-4.1.2a.json
+++ b/Testreglar/4.1.2/Nett/nett-4.1.2a.json
@@ -1,11 +1,11 @@
 {
-	"namn": "4.1.2a Skjemaelement er identifiserte i koden",
-	"id": "4.1.2a",
-	"testlabId": 245,
+	"namn": "Nett-4.1.2a For skjemaelementer kan tilgjengelig navn, rolle og tilstand bestemmes programmatisk  2023",
+	"id": "nett-4.1.2a",
+	"testlabId": 435,
 	"versjon": "1.0",
 	"type": "Nett",
-	"spraak": "nn",
-	"kravTilSamsvar": "<p>Skjemaelement er kopla til ein ledetekst i koden. Dette kan gjerast på fleire måtar. Ledeteksten identifiserer skjemaelementet.</p>\r\n<p>Dersom skjemaelementet høyrer til ei gruppe, er det i tillegg kopla til ein ledetekst som gjeld for gruppa. Ledeteksten identifiserer gruppa.</p>",
+	"spraak": "nb",
+	"kravTilSamsvar": "<p>Det er flere måter å oppfylle kravet på.</p>\r\n<p>Navn og rolle:</p>\r\n<ul>\r\n<li>Alle skjemaelementer har et tilgjengelig navn, som beskriver formålet med det aktuelle elementet og </li>\r\n<li>Skjemaelementer som tilhører en gruppe, er også koblet til et tilgjengelig navn som gjelder for gruppen og</li>\r\n<li>Alle skjemaelementer har riktig rolle, som identifiserer funksjonen til det aktuelle elementet</li>\r\n</ul>\r\n<p>Tilstander, egenskaper og verdier:</p>\r\n<ul>\r\n<li>Når tilstander, egenskaper og verdier i skjemaelementer kan angis av brukeren, skal denne informasjonen også angis programmatisk og</li>\r\n<li>Varsel om endringer i den aktuelle elementet er tilgjengelig for brukeragenter </li>\r\n</ul>\r\n<p> </p>",
 	"side": "2.1",
 	"element": "3.1",
 	"kolonner": [
@@ -65,20 +65,16 @@
 		},
 		{
 			"title": "3.19"
-		},
-		{
-			"title": "3.20"
 		}
 	],
 	"steg": [
 		{
 			"stegnr": "2.1",
-			"spm": "Kva side testar du på?",
-			"ht": "Oppgi url eller side-ID.",
+			"spm": "Hvilken side tester du?",
+			"ht": "<p>Angi URL eller side-ID.</p>",
 			"type": "tekst",
-			"label": "Url/Side:",
+			"label": "URL/Side:",
 			"datalist": "Sideutvalg",
-			"oblig": true,
 			"ruting": {
 				"alle": {
 					"type": "gaaTil",
@@ -88,8 +84,8 @@
 		},
 		{
 			"stegnr": "2.2",
-			"spm": "Har nettsida skjemaelement?",
-			"ht": "<p>Sjekk om nettsida har skjemaelement av type avkryssingsboks, radioknapp, tekstfelt eller nedtrekksliste.</p><p>Du skal teste både <strong>aktive</strong> og <strong>inaktive</strong> skjemaelement.</p><p><strong>Merk:</strong> Du skal ikkje teste knappar. Knappar blir brukt for eksempel til å aktivere ein funksjon eller sende inn skjema.</p>",
+			"spm": "Bruk verktøyet og sjekk om det gir resultater under \"Form control has accessible name\".",
+			"ht": "<p>Slik tester du:</p>\n<ul>\n<li>Bruk verktøyet <a href=\"https://chrome.google.com/webstore/detail/qualweb-extension/ljgilomdnehokancdcbkmbndkkiggioc\" target=\"_blank\" rel=\"noopener\">QualWeb </a>i Chrome på testsiden\n<ul>\n<li>velg kun \"ACT Rules\"</li>\n<li>trykk på knappen \"Evaluate\"</li>\n<li>utvid \"Fliters\"</li>\n<li>fjern hake på \"Warning\"</li>\n</ul>\n</li>\n<li>Sjekk om det finnes resultater på \"Form control has accessible name\"<br>\n<ul>\n<li>trykk på \"Form control has accessible name\" for å vise aktuelle resultater\n<ul>\n<li>Dersom alternativene ikke kommer opp, har ikke QW funnet skjemaelementer</li>\n</ul>\n</li>\n<li>velg både Passed og Failed</li>\n<li>du kan bruke \"Highlight Element\" for å vise hvor aktuelle elementer ligger på siden\n<ul>\n<li>Bruk pilene for å navigere gjennom resultater for forskjellige elementer</li>\n</ul>\n</li>\n</ul>\n</li>\n</ul>\n<p><strong>Merk:</strong></p>\n<ul>\n<li><strong>Du skal ikke teste knapper. Knapper har egen testregel.</strong> \n<ul>\n<li>Knapper blir  for eksempel brukt til å aktivere en funksjon eller sende inn skjema. </li>\n</ul>\n</li>\n<li>Du skal teste både aktive og inaktive skjemaelementer.</li>\n<li>Hvis verktøyet ikke finner skjemaelementer, velger du \"Nei\" i dette steget</li>\n</ul>",
 			"type": "jaNei",
 			"ruting": {
 				"ja": {
@@ -97,33 +93,37 @@
 					"steg": "3.1"
 				},
 				"nei": {
-					"type": "ikkjeForekomst",
-					"utfall": "Testside har ikkje skjema."
+					"type": "gaaTil",
+					"steg": "3.19"
 				}
 			}
 		},
 		{
 			"stegnr": "3.1",
-			"spm": "Beskriv skjemaelementet som skal vurderast.",
-			"ht": "<p>Legg inn overskrift, eller andre stikkord som er slik at skjemaelementet kan identifiserast.</p>",
+			"spm": "Hvilket skjemaelement tester du?",
+			"ht": "<p>Beskriv skjemaelement, slik at det er mulig å identifisere det i ettertid. Hvis verktøyet finner flere skjemaelementer, registrerer du et og et.</p>",
 			"type": "tekst",
-			"label": "Element",
-			"multilinje": true,
-			"oblig": true,
 			"ruting": {
 				"alle": {
 					"type": "gaaTil",
 					"steg": "3.2"
 				}
-			}
+			},
+			"label": "Skjemaelement:",
+			"multilinje": true
 		},
 		{
 			"stegnr": "3.2",
-			"spm": "Er skjemaelementet ein del av den globale søkefunksjonen?",
-			"ht": "Ein global søkefunksjon er ein navigasjonsmekanisme som let brukaren søke i alle sidene på nettstaden.",
+			"spm": "Har verktøyet funnet brudd for dette skjemaelementet?",
+			"ht": "<p>Hvis Qualweb gir resultat:</p>\n<ul>\n<li>\"Failed\": Det er brudd og testen avsluttes.</li>\n<li>\"Passed\": Skjemaelementet skal testes videre.</li>\n</ul>",
 			"type": "jaNei",
 			"ruting": {
-				"alle": {
+				"ja": {
+					"type": "avslutt",
+					"fasit": "Nei",
+					"utfall": "Skjemaelementet har ikke et tilgjengelig navn."
+				},
+				"nei": {
 					"type": "gaaTil",
 					"steg": "3.3"
 				}
@@ -131,14 +131,18 @@
 		},
 		{
 			"stegnr": "3.3",
-			"spm": "Korleis er skjemaelementet koda?",
-			"ht": "<p>Du kan bruke kodeverktøyet i nettlesaren for å sjekke dette. Skjemaelement er vanlegvis koda som <code>&#x3C;input&#x3E;</code> , <code>&#x3C;select&#x3E;</code> eller <code>&#x3C;textarea&#x3E;</code>.</p><strong>Merk:</strong> Du skal ikkje teste knappar.</p>",
+			"spm": "Hvilken type skjemaelement tester du?",
+			"ht": "<p>Velg type skjemaelement i listen.</p>",
 			"type": "radio",
 			"svarArray": [
-				"Input",
-				"Select",
-				"Textarea",
-				"Anna"
+				"avkryssningsboks",
+				"nedtrekksliste",
+				"radioknapp",
+				"inndatafelt",
+				"søkefelt",
+				"switch",
+				"listeboks",
+				"annet"
 			],
 			"ruting": {
 				"alle": {
@@ -149,56 +153,69 @@
 		},
 		{
 			"stegnr": "3.4",
-			"spm": "Har skjemaelementet attributtet \"aria-label\" ?",
-			"ht": "<p>Sjå i koden og finn skjemaelementet.</p><p><strong>Merk:</strong> Du skal ikkje vurdere kvaliteten på teksten.</p>",
+			"spm": "Har skjemaelementet et tilgjengelig navn, som ikke er tomt?",
+			"ht": "<p>Slik tester du:</p>\n<p><strong>Alternativ 1:</strong></p>\n<ul>\n<li>Åpne DevTools i nettleseren (F12) Chrome</li>\n<li>Inspiser skjemaelementet med funksjonen \"inspiser element med mus\"\n<ul>\n<li>Klikk på pil-knappen i øvre venstre hjørne av vinduet, for å aktivere funksjonen</li>\n</ul>\n</li>\n<li>Hold musepekeren over skjemaelementet du tester</li>\n<li>En pop-up viser blant annet \"Name\" og \"Role\" under overskriften \"Accessibility\"</li>\n<li>Sjekk om informasjon under \"Name\" er ikke tomt</li>\n</ul>\n<p><strong>Alternativ 2:</strong></p>\n<ul>\n<li>Inspiser skjemaelementet i Chrome</li>\n<li>Bruk Accessibility Checker verktøy i inspiser</li>\n<li>Under Computed Properties, finner du blant annet \"Name\" og \"Role\"</li>\n<li>Sjekk at informasjon under \"Name\" ikke er tomt.</li>\n</ul>",
 			"type": "jaNei",
-			"kilde": [
-				"ARIA14"
-			],
 			"ruting": {
 				"ja": {
 					"type": "gaaTil",
-					"steg": "3.10"
+					"steg": "3.5"
 				},
 				"nei": {
-					"type": "gaaTil",
-					"steg": "3.5"
+					"type": "avslutt",
+					"fasit": "Nei",
+					"utfall": "Skjemaelementet har ikke et tilgjengelig navn."
 				}
-			}
+			},
+			"kilde": [
+				"ARIA14",
+				"ARIA16",
+				"F68",
+				"F86",
+				"G108",
+				"H44",
+				"H65",
+				"H88",
+				"H91"
+			]
 		},
 		{
 			"stegnr": "3.5",
-			"spm": "Har skjemaelementet attributtet \"aria-labelledby\" ?",
-			"ht": "<p>Merk at ein aria-labelledby kan innhalde fleire id-ar i same attributt. Id-ane er skilt med mellomrom. (<code>Aria-labelledby=\"id1 id2\"</code>)</p><strong>Merk:</strong> Du skal ikkje vurdere kvaliteten på teksten. ",
+			"spm": "Beskriver tilgjengelig navn formålet med skjemaelementet?",
+			"ht": "<p>Slik tester du:</p>\n<ul>\n<li>Ta utgangspunkt i det tilgjengelige navnet du fant i forrige steg.</li>\n<li>Sjekk om det tilgjengelige navnet beskriver formålet med skjemaelementet. Det er tilstrekkelig at det tilgjengelige navnet identifiserer skjemaelementet.</li>\n</ul>",
 			"type": "jaNei",
-			"kilde": [
-				"ARIA16"
-			],
 			"ruting": {
 				"ja": {
 					"type": "gaaTil",
 					"steg": "3.6"
 				},
 				"nei": {
-					"type": "gaaTil",
-					"steg": "3.7"
+					"type": "avslutt",
+					"fasit": "Nei",
+					"utfall": "Skjemaelementet har et tilgjengelig navn, som ikke beskriver formålet med elementet."
 				}
-			}
+			},
+			"kilde": [
+				"ARIA14"
+			]
 		},
 		{
 			"stegnr": "3.6",
-			"spm": "Er aria-labelledby attributtet kopla til annan tekst på sida (lenkekontekst)?",
-			"ht": "<p>Gjer eit søk i koden på id i aria-labelledby. Dersom det finst fleire id-ar, skal du undersøke alle. Id-ane vil då vere skilt med mellomrom. (<code>Aria-labelledby=\"id1 id2\"</code>).</p>",
-			"type": "jaNei",
-			"kilde": [
-				"ARIA16"
+			"spm": "Hvilket attributt gir tilgjengelig navn til skjemaelementet?",
+			"ht": "<ul>\n<li>Sjekk dette under \"Name\" under Computed Properties i Accessibility Checker</li>\n<li>Velg et alternativ</li>\n</ul>",
+			"type": "radio",
+			"svarArray": [
+				"aria-labelledby",
+				"aria-label",
+				"label",
+				"innhold",
+				"title",
+				"alt",
+				"value",
+				"annet"
 			],
 			"ruting": {
-				"ja": {
-					"type": "gaaTil",
-					"steg": "3.10"
-				},
-				"nei": {
+				"alle": {
 					"type": "gaaTil",
 					"steg": "3.7"
 				}
@@ -206,93 +223,78 @@
 		},
 		{
 			"stegnr": "3.7",
-			"spm": "Er skjemaelementet kopla til eit &#x3C;label&#x3E;-element i koden?",
-			"ht": "<p>Du kan bruke kodeverktøyet i nettlesaren for å sjekke dette. Sjekk at:</p> <ol> <li> Skjemaelementet har eit id-attributt. </li> <li><code>&#x3C;label&#x3E;</code>-elementet har eit for-attributt.</li> <li>Innhaldet i <code>&#x3C;label&#x3E;</code>-elementet sitt for-attributt er det same som innhaldet i skjemaelementet sitt id-attributt.</li> </ol> <p>Det er nok at verdien er lik.</p> <p><strong>Merk:</strong> Det er ikkje tilstrekkeleg at svaralternativ i ei nedtrekksliste har label-attributt, fordi dette fungerer som identifikasjon til svaralternativet og ikkje til lista.</p>",
+			"spm": "Er skjemaelementet kodet med riktig rolle?",
+			"ht": "<p>Det er flere måter å kode et skjemaelement, men det skal alltid ha en rolle i Accessibility Tree, som identifiserer funksjonen til det aktuelle skjemaelementet.</p>\n<p>Slik tester du:</p>\n<ul>\n<li>Åpne Accessibility Checker i DevTools i nettleseren (F12) Chrome</li>\n<li>Sjekk om informasjon under \"Role\" er i samsvar med funksjonen til skjemaelementet</li>\n<li>Eksempler:  \n<ul>\n<li>avkryssingsboks: <a href=\"https://www.w3.org/TR/wai-aria-1.2/#checkbox\" target=\"_blank\" rel=\"noopener\">checkbox</a></li>\n<li>nedtrekksliste: <a href=\"https://www.w3.org/TR/wai-aria-1.2/#combobox\" target=\"_blank\" rel=\"noopener\">combobox</a></li>\n<li>radioknapp: <a href=\"https://www.w3.org/TR/wai-aria-1.2/#radio\" target=\"_blank\" rel=\"noopener\">radio</a></li>\n<li>inndatafelt: <a href=\"https://www.w3.org/TR/wai-aria-1.2/#textbox\" target=\"_blank\" rel=\"noopener\">textbox</a></li>\n<li>søkefelt: <a href=\"https://www.w3.org/TR/wai-aria-1.2/#searchbox\" target=\"_blank\" rel=\"noopener\">searchbox</a></li>\n<li>switch: <a href=\"https://www.w3.org/TR/wai-aria-1.2/#switch\" target=\"_blank\" rel=\"noopener\">switch</a></li>\n<li>listeboks: <a href=\"https://www.w3.org/TR/wai-aria-1.2/#listbox\" target=\"_blank\" rel=\"noopener\">listbox</a></li>\n<li>annet: andre relevante roller i <a href=\"https://www.w3.org/TR/wai-aria-1.2/#widget_roles\" target=\"_blank\" rel=\"noopener\">Widget Roles</a></li>\n</ul>\n</li>\n</ul>",
 			"type": "jaNei",
-			"kilde": [
-				"G108",
-				"H44",
-				"H91",
-				"F68",
-				"F86"
-			],
 			"ruting": {
 				"ja": {
 					"type": "gaaTil",
-					"steg": "3.10"
+					"steg": "3.8"
 				},
 				"nei": {
-					"type": "gaaTil",
-					"steg": "3.8"
+					"type": "avslutt",
+					"fasit": "Nei",
+					"utfall": "Skjemaelementet har tilgjengelig navn, men er ikke kodet med riktig rolle, som identifiserer funksjonen til det aktuelle elementet."
 				}
-			}
+			},
+			"kilde": [
+				"ARIA4",
+				"F59",
+				"G10"
+			]
 		},
 		{
 			"stegnr": "3.8",
-			"spm": "Ligg skjemaelementet inne i eit &#x3C;label&#x3E;-element i koden?",
-			"ht": "<p>Du kan bruke kodeverktøyet i nettlesaren for å sjekke dette. Sjå om det finst eit <code>&#x3C;label&#x3E;</code><-element som starter framføre og blir avslutta etter skjemaelementet. Du må kanskje felle ut <code>&#x3C;label&#x3E;</code>-elementet i koden for å sjå all koding.</p><p>I dette tilfellet er ledeteksten all tekst som ligg inne i <code>&#x3C;label&#x3E;</code>-elementet.</p>",
+			"spm": "Må skjemaelementet være koblet til et annet skjemaelement for å gi mening?",
+			"ht": "<p>Eksempel på dette er at grupper av radioknapper eller avkryssingsbokser må leses i sammenheng med et overordnet spørsmål.</p>\n<p>Andre eksempler på gruppe er tekstfelt for telefonnummer med et felt for landskode og et felt for telefonnummer gruppert sammen i et element.</p>\n<p>En tommelfingerregel er at når en gruppe med skjemaelementer krever en egen overskrift, er det riktig å kode med fieldset og legend.</p>",
 			"type": "jaNei",
-			"kilde": [
-				"F68"
-			],
 			"ruting": {
 				"ja": {
 					"type": "gaaTil",
-					"steg": "3.10"
+					"steg": "3.9"
 				},
 				"nei": {
 					"type": "gaaTil",
-					"steg": "3.9"
+					"steg": "3.16"
 				}
 			}
 		},
 		{
 			"stegnr": "3.9",
-			"spm": "Har skjemaelementet eit title-attributt?",
-			"ht": "Du kan nytte kodeverktøyet i nettlesaren til å sjekke dette.",
+			"spm": "Ligger skjemaelementet inne i et &lt;fieldset&gt;-element?",
+			"ht": "<p>Du kan bruke DevTools i nettleseren (F12) Chrome for å sjekke dette.</p>",
 			"type": "jaNei",
-			"kilde": [
-				"G108",
-				"H65",
-				"H91",
-				"F68"
-			],
 			"ruting": {
 				"ja": {
 					"type": "gaaTil",
 					"steg": "3.10"
 				},
 				"nei": {
-					"type": "avslutt",
-					"fasit": "Nei",
-					"utfall": "Skjemaelement er ikkje er kopla til ein ledetekst i koden."
+					"type": "gaaTil",
+					"steg": "3.13"
 				}
 			}
 		},
 		{
 			"stegnr": "3.10",
-			"spm": "Identifiserer ledeteksten skjemaelementet?",
-			"ht": "<p>Ta utgangspunktet i ledeteksten du fann i førre steg. Det er tilstrekkeleg at ledeteksten identifiserer skjemaelementet.</p><p><Strong>Merk:</strong> Ledeteksten skal vere på same språk som skjemaet.</p>",
+			"spm": "Ligger det et &lt;legend&gt;-element inne i &lt;fieldset&gt;-elementet?",
+			"ht": "<p>Du kan bruke DevTools i nettleseren (F12) Chrome for å sjekke dette.</p>",
 			"type": "jaNei",
-			"kilde": [
-				"G108"
-			],
 			"ruting": {
 				"ja": {
 					"type": "gaaTil",
 					"steg": "3.11"
 				},
 				"nei": {
-					"type": "avslutt",
-					"fasit": "Nei",
-					"utfall": "Skjemaelement er kopla til ein ledetekst i koden. Ledeteksten identifiserer ikkje skjemaelementet."
+					"type": "gaaTil",
+					"steg": "3.13"
 				}
 			}
 		},
 		{
 			"stegnr": "3.11",
-			"spm": "Må skjemaelementet vere kopla til ein annan ledetekst/spørsmål for å gi meining?",
-			"ht": "<p>Eksempel på dette er grupper av radioknappar eller avkryssingsboksar som må lesast i samanheng med eit overordna spørsmål.</p><p>Ein tommelfingerregel er at når ei gruppe med skjemaelement krever ei egen overskrift, er det riktig å bruke fieldset og legend.</p> ",
+			"spm": "Er &lt;legend&gt; det første elementet som ligger inne i &lt;fieldset&gt;?",
+			"ht": "<p>Du kan bruke DevTools i nettleseren (F12) Chrome for å sjekke dette.</p>",
 			"type": "jaNei",
 			"ruting": {
 				"ja": {
@@ -300,26 +302,22 @@
 					"steg": "3.12"
 				},
 				"nei": {
-					"type": "avslutt",
-					"fasit": "Ja",
-					"utfall": "Skjemaelement er kopla til ein ledetekst i koden. Ledeteksten identifiserer skjemaelementet."
+					"type": "gaaTil",
+					"steg": "3.13"
 				}
 			}
 		},
 		{
 			"stegnr": "3.12",
-			"spm": "Ligg skjemaelementet inne i eit &#x3C;fieldset&#x3E;-element?",
-			"ht": "Du kan bruke kodeverktøyet i nettlesaren for å sjekke dette.",
+			"spm": "Blir skjemaelementet identifisert av innholdet i &lt;legend&gt; kombinert med skjemaelementets tilgjengelig navn?",
+			"ht": "<p>Du skal vurdere skjemaelementets tilgjengelige navn og innholdet i <code>&lt;legend&gt;</code> samlet.</p>",
 			"type": "jaNei",
-			"kilde": [
-				"H71"
-			],
 			"ruting": {
-				"ja": {
+				"nei": {
 					"type": "gaaTil",
 					"steg": "3.13"
 				},
-				"nei": {
+				"ja": {
 					"type": "gaaTil",
 					"steg": "3.16"
 				}
@@ -327,161 +325,127 @@
 		},
 		{
 			"stegnr": "3.13",
-			"spm": "Ligg det eit &#x3C;legend&#x3E;-element inne i eit &#x3C;fieldset&#x3E;-elementet?",
-			"ht": "Du kan bruke kodeverktøyet i nettlesaren for å sjekke dette.",
+			"spm": "Ligger skjemaelementet inne i et annet element med attributtet role=\"group\"?",
+			"ht": "<p>Slik tester du:</p>\n<p>Element som starter framfor og blir avsluttet etter skjemaelementet du tester. Role-attributtet kan for eksempel ligge på en <code>&lt;div&gt;</code> eller <code>&lt;span&gt;</code>.</p>\n<ul>\n<li>Åpne Accessibility Checker i DevTools i nettleseren (F12) Chrome</li>\n<li>Sjekk om informasjon under \"Role\" er \"group\"</li>\n</ul>",
 			"type": "jaNei",
-			"kilde": [
-				"H71"
-			],
 			"ruting": {
+				"nei": {
+					"type": "avslutt",
+					"fasit": "Nei",
+					"utfall": "Skjemaelementetet har tilgjengelig navn og er kodet med riktig rolle. Skjemaelementet er plassert i en gruppe som ikke er identifisert i koden."
+				},
 				"ja": {
 					"type": "gaaTil",
 					"steg": "3.14"
-				},
-				"nei": {
-					"type": "gaaTil",
-					"steg": "3.16"
 				}
 			}
 		},
 		{
 			"stegnr": "3.14",
-			"spm": "Er &#x3C;legend&#x3E; det første elementet som ligg inne i &#x3C;fieldset&#x3E;?",
-			"ht": "Du kan bruke kodeverktøyet i nettlesaren for å sjekke dette.",
+			"spm": "Har elementet med rolle group et tilgjengelig navn, som ikke er tomt?",
+			"ht": "<p>Slik tester du:</p>\n<ul>\n<li>Åpne Accessibility Checker i DevTools i nettleseren (F12) Chrome</li>\n<li>Sjekk at informasjon under \"Name\" ikke er tomt.</li>\n</ul>",
 			"type": "jaNei",
-			"kilde": [
-				"H71"
-			],
 			"ruting": {
 				"ja": {
 					"type": "gaaTil",
 					"steg": "3.15"
 				},
 				"nei": {
-					"type": "gaaTil",
-					"steg": "3.16"
+					"type": "avslutt",
+					"fasit": "Nei",
+					"utfall": "Skjemaelementet har tilgjengelig navn og er kodet med riktig rolle. Skjemaelement er plassert i en gruppe som ikke har et tilgjengelig navn."
 				}
 			}
 		},
 		{
 			"stegnr": "3.15",
-			"spm": "Blir skjemaelementet identifisert av innhaldet i &#x3C;legend&#x3E; saman med skjemaelementet sin ledetekst?",
-			"ht": "<p>Du skal vurdere samla både skjemaelementet sin ledetekst og innhaldet i <code>&#x3C;legend&#x3E;.</code></p>",
+			"spm": "Blir skjemaelementet identifisert av det tilgjengelige navnet for gruppen kombinert med skjemaelementets tilgjengelige navn?",
+			"ht": "<p>Du skal vurdere både skjemaelementets tilgjengelig navn og det tilgjengelige navnet for gruppen som skjemaelementet ligger inne i samlet. </p>",
 			"type": "jaNei",
-			"kilde": [
-				"H71"
-			],
 			"ruting": {
 				"ja": {
-					"type": "avslutt",
-					"fasit": "Ja",
-					"utfall": "Skjemaelement er kopla til ein ledetekst i koden. Skjemaelement er plassert i ei gruppe i koden. Ledetekst identifiserer skjemaelementet."
-				},
-				"nei": {
 					"type": "gaaTil",
 					"steg": "3.16"
+				},
+				"nei": {
+					"type": "avslutt",
+					"fasit": "Nei",
+					"utfall": "Skjemaelementetet har tilgjengelig navn og er kodet med riktig rolle. Skjemaelementet er plassert i en gruppe som har et tilgjengelig navn, men det tilgjengelige navnet for gruppen identifiserer ikke formålet med skjemaelementet."
 				}
 			}
 		},
 		{
 			"stegnr": "3.16",
-			"spm": "Ligg skjemaelementet inne i eit anna element med attributtet role=\"group\"?",
-			"ht": "<p>Du kan bruke kodeverktøyet i nettlesaren for å sjekke dette.</p><p>Dette element som starter framføre og blir avslutta etter skjemaelementet du testar. Role-attributtet kan for eksempel ligge på ein <code>&#x3C;div&#x3E;</code> eller <code>&#x3C;span&#x3E;</code>.</p>",
+			"spm": "Har skjemaelementet mer enn en tilstand når brukeren samhandler med den?",
+			"ht": "<p>En tilstand er en dynamisk egenskap som endres når brukeren samhandler med skjemaelementet.</p>\n<p>Trykk på skjemaelementet og sjekk om elementet har minst en av disse tilstandene: </p>\n<ul>\n<li>avkryssingsboks eller radioknapp: checkbox eller radio - avkrysset eller ikke avkrysset</li>\n<li>nedtrekksliste: combobox - utvidet eller sammensluttet</li>\n<li>inndatafelt: textbox - utfylt eller ikke utfylt</li>\n<li>switch: switch - av/på</li>\n<li>annet: andre relevante tilstander (State) knyttet til <a href=\"https://www.w3.org/TR/wai-aria-1.2/#widget_roles\" target=\"_blank\" rel=\"noopener\">Widget Roles</a></li>\n</ul>",
 			"type": "jaNei",
-			"kilde": [
-				"ARIA17"
-			],
 			"ruting": {
+				"nei": {
+					"type": "avslutt",
+					"fasit": "Ja",
+					"utfall": "Skjemaelementet har et tilgjengelig navn, og riktig rolle,  som beskriver formålet med det aktuelle elementet."
+				},
 				"ja": {
 					"type": "gaaTil",
 					"steg": "3.17"
-				},
-				"nei": {
-					"type": "avslutt",
-					"fasit": "Nei",
-					"utfall": "Skjemaelement er kopla til ein ledetekst i koden. Skjemaelement er plassert i ei gruppe som ikkje er identifisert i koden."
 				}
 			}
 		},
 		{
 			"stegnr": "3.17",
-			"spm": "Har dette elementet attributtet \"aria-label\" ?",
-			"ht": "<p>Sjå i koden og finn skjemaelementet.</p><p><strong>Merk:</strong> Du skal ikkje vurdere kvaliteten på teksten. </p>",
-			"type": "jaNei",
-			"kilde": [
-				"ARIA17"
-			],
+			"spm": "Hvilken tilstand tester du?",
+			"ht": "<p>Beskriv tilstanden, slik at det er mulig å identifisere den i ettertid.</p>",
+			"type": "tekst",
 			"ruting": {
-				"ja": {
-					"type": "gaaTil",
-					"steg": "3.20"
-				},
-				"nei": {
+				"alle": {
 					"type": "gaaTil",
 					"steg": "3.18"
 				}
-			}
+			},
+			"label": "Tilstand:",
+			"multilinje": true
 		},
 		{
 			"stegnr": "3.18",
-			"spm": "Har dette elementet attributtet \"aria-labelledby\" ?",
-			"ht": "<p>Merk at ein aria-labelledby kan innhalde fleire id-ar i same attributt. Id-ane er skilt med mellomrom. (<code>Aria-labelledby=\"id1 id2\"</code>)</p><p><strong>Merk:</strong> Du skal ikkje vurdere kvaliteten på teksten. </p>",
+			"spm": "Er den aktuelle tilstanden angitt programmatisk?",
+			"ht": "<p>Slik tester du:</p>\n<ul>\n<li>Inspiser skjemaelementet i Chrome</li>\n<li>Bruk Accessibility Checker</li>\n<li>Under ARIA-attributter eller Computed Properties, sjekk om det finnes:\n<ul>\n<li>avkryssingsboks eller radioknapp\n<ul>\n<li>hvis avkrysset: aria-checked: true eller Checked: true</li>\n<li>hvis ikke avkrysset: aria-checked: false eller Checked: false</li>\n</ul>\n</li>\n<li>nedtrekksliste<br>\n<ul>\n<li>hvis innholdet er sammensluttet: aria-expanded: false eller Expanded: false</li>\n<li>hvis innholdet er utvidet: aria-expanded: true eller Expanded: true</li>\n</ul>\n</li>\n<li>switch\n<ul>\n<li>hvis knappen er på: aria-pressed: true eller aria-checked: true</li>\n<li>hvis knappen er av: aria-pressed: false eller aria-checked: false</li>\n<li>hvis knappen har en mellomliggende tilstand mellom tilstander av og på: aria-pressed: mixed.</li>\n</ul>\n</li>\n<li>annet: andre relevante tilstander (State) knyttet til <a href=\"https://www.w3.org/TR/wai-aria-1.2/#widget_roles\" target=\"_blank\" rel=\"noopener\">Widget Roles</a></li>\n</ul>\n</li>\n</ul>",
 			"type": "jaNei",
-			"kilde": [
-				"ARIA17"
-			],
-			"ruting": {
-				"ja": {
-					"type": "gaaTil",
-					"steg": "3.19"
-				},
-				"nei": {
-					"type": "avslutt",
-					"fasit": "Nei",
-					"utfall": "Skjemaelement er kopla til ein ledetekst i koden. Skjemaelement er plassert i ei gruppe som ikkje er identifisert i koden."
-				}
-			}
-		},
-		{
-			"stegnr": "3.19",
-			"spm": "Er aria-labelledby attributtet kopla til annan tekst på sida (lenkekontekst)?",
-			"ht": "<p>Gjer eit søk i koden på id i aria-labelledby. Dersom det finst fleire id-ar, skal du undersøke alle. Id-ane vil då vere skilt med mellomrom. (<code>Aria-labelledby=\"id1 id2\"</code>)</p>",
-			"type": "jaNei",
-			"kilde": [
-				"ARIA17"
-			],
-			"ruting": {
-				"ja": {
-					"type": "gaaTil",
-					"steg": "3.20"
-				},
-				"nei": {
-					"type": "avslutt",
-					"fasit": "Nei",
-					"utfall": "Skjemaelement er kopla til ein ledetekst i koden. Skjemaelement er plassert i ei gruppe som ikkje er identifisert i koden."
-				}
-			}
-		},
-		{
-			"stegnr": "3.20",
-			"spm": "Blir skjemaelementet identifisert av innhaldet i dette aria-attributtet saman med skjemaelementet sin ledetekst?",
-			"ht": "Du skal vurdere samla både skjemaelementet sin ledetekst og innhaldet i aria-attributtet til elementet som skjemaelementet ligg inne i.",
-			"type": "jaNei",
-			"kilde": [
-				"G108"
-			],
 			"ruting": {
 				"ja": {
 					"type": "avslutt",
 					"fasit": "Ja",
-					"utfall": "Skjemaelement er kopla til ein ledetekst i koden. Skjemaelement er plassert i ei gruppe i koden. Ledetekst identifiserer skjemaelementet."
+					"utfall": "Skjemaelementet har et tilgjengelig navn, og riktig rolle, som beskriver formålet med det aktuelle elementet. Tilstanden er angitt programmatisk."
 				},
 				"nei": {
 					"type": "avslutt",
 					"fasit": "Nei",
-					"utfall": "Skjemaelement er kopla til ein ledetekst i koden. Skjemaelement er plassert i ei gruppe som ikkje er identifisert i koden."
+					"utfall": "Skjemaelementet har et tilgjengelig navn, og riktig rolle, som beskriver formålet med det aktuelle elementet. Tilstanden er ikke angitt programmatisk."
 				}
-			}
+			},
+			"kilde": [
+				"ARIA5",
+				"G10"
+			]
+		},
+		{
+			"stegnr": "3.19",
+			"spm": "Har testsiden skjemaelementer som verktøyet ikke avdekker?",
+			"ht": "<p>Gjør en visuell inspeksjon og sjekk om det finnes flere skjemaelementer på testsiden.</p>\n<p>Begrensninger i verktøyet</p>\n<ul>\n<li>Det finner kun skjemaelementer som har en rolle fra <a href=\"https://www.w3.org/TR/wai-aria-1.2/#widget_roles\" target=\"_blank\" rel=\"noopener\">Widget Role</a></li>\n<li>Det finner ikke skjemaelementer kodet på andre måter, for eksempel <code>&lt;div&gt;</code>, <code>&lt;span&gt;</code> eller lignende  </li>\n</ul>\n<p><strong>Skjemaelement:</strong> Eksempel på skjemaelementer er avkryssningsboks, nedtrekksliste, radioknapp, inndatafelt, søkefelt, switch og listeboks.</p>",
+			"type": "jaNei",
+			"ruting": {
+				"ja": {
+					"type": "gaaTil",
+					"steg": "3.1"
+				},
+				"nei": {
+					"type": "ikkjeForekomst",
+					"utfall": "Testsiden har ikke skjemaelementer."
+				}
+			},
+			"kilde": [
+				"F20",
+				"F59"
+			]
 		}
 	]
 }


### PR DESCRIPTION
Vi lager ikke testregel for følgende ACT-regler, fordi de kan testes automatisk:

- 6cfa84 – Element with aria-hidden has no content in sequential focus navigation: 
- 307n5z – Element with presentational children has no focusable content
- 4e8ab6 – Element with role attribute has required states and properties