### PR TITLE
nett-1.1.1a er klar for ks

### DIFF
--- a/Testreglar/1.1.1/Nett/nett-1.1.1a-L-AHN-T14.json
+++ b/Testreglar/1.1.1/Nett/nett-1.1.1a-L-AHN-T14.json
@@ -1,0 +1,749 @@
+{
+	"namn": "1.1.1a Bilde har tekstalternativ",
+	"id": "1.1.1a",
+	"testlabId": 153,
+	"versjon": "1.0",
+	"type": "Nett",
+	"spraak": "nn",
+	"kravTilSamsvar": "<p>For bilde i HTML er ein av følgjande er oppfylt:</p>\r\n<ul>\r\n<li>Bilde som er pynt er koda på en slik måte at dei ikkje er til støy.</li>\r\n<li>Bilde som er ei sanseoppleving eller ein test har eit kort tekstalternativ som gir ein beskrivande identifikasjon.</li>\r\n<li>Bilde som er meiningsberande har eit kort tekstalternativ som gjengir same informasjon som biletet.</li>\r\n<li>Bilde som er komplekse har både eit kort tekstalternativ og eit utfyllande tekstalternativ.</li>\r\n</ul>",
+	"side": "2.1",
+	"element": "3.1",
+	"kolonner": [
+		{
+			"title": "2.2"
+		},
+		{
+			"title": "3.2"
+		},
+		{
+			"title": "3.3"
+		},
+		{
+			"title": "3.4"
+		},
+		{
+			"title": "3.5"
+		},
+		{
+			"title": "3.6"
+		},
+		{
+			"title": "3.7"
+		},
+		{
+			"title": "3.8"
+		},
+		{
+			"title": "3.9"
+		},
+		{
+			"title": "3.10"
+		},
+		{
+			"title": "3.11"
+		},
+		{
+			"title": "3.12"
+		},
+		{
+			"title": "3.13"
+		},
+		{
+			"title": "3.14"
+		},
+		{
+			"title": "3.15"
+		},
+		{
+			"title": "3.16"
+		},
+		{
+			"title": "3.17"
+		},
+		{
+			"title": "3.18"
+		},
+		{
+			"title": "3.19"
+		},
+		{
+			"title": "3.20"
+		},
+		{
+			"title": "3.21"
+		},
+		{
+			"title": "3.22"
+		},
+		{
+			"title": "3.23"
+		},
+		{
+			"title": "3.24"
+		},
+		{
+			"title": "3.25"
+		},
+		{
+			"title": "3.26"
+		},
+		{
+			"title": "3.27"
+		},
+		{
+			"title": "3.28"
+		},
+		{
+			"title": "3.29"
+		},
+		{
+			"title": "3.30"
+		}
+	],
+	"steg": [
+		{
+			"stegnr": "2.1",
+			"spm": "Kva side testar du på?",
+			"ht": "<p>Oppgi URL eller side-ID.</p>",
+			"type": "tekst",
+			"label": "URL/Side:",
+			"datalist": "Sideutvalg",
+			"oblig": true,
+			"ruting": {
+				"alle": {
+					"type": "gaaTil",
+					"steg": "2.2"
+				}
+			}
+		},
+		{
+			"stegnr": "2.2",
+			"spm": "Finst det ikkje-lenka bilde på nettsida?",
+			"ht": "<p>Du skal teste alle bilde som ikkje er lenka. Bilde kan for eksempel vere</p><ul><li>illustrasjonar</li><li>pyntebilde og dekor</li><li>grafar og diagram</li><li>ikon og symbol</li></ul><p>Bilde kan vere koda inni andre HTML-element, som for eksempel <Code>&#x3C;figure&#x3E;</code>.</p>",
+			"type": "jaNei",
+			"ruting": {
+				"ja": {
+					"type": "gaaTil",
+					"steg": "3.1"
+				},
+				"nei": {
+					"type": "ikkjeForekomst",
+					"utfall": "Testside har ingen ikkje-lenka bilde."
+				}
+			}
+		},
+		{
+			"stegnr": "3.1",
+			"spm": "Beskriv bilde",
+			"ht": "Du kan for eksempel beskrive motiv, plassering på sida, element som er i nærleiken.",
+			"type": "tekst",
+			"label": "Bilde:",
+			"multilinje": true,
+			"oblig": true,
+			"ruting": {
+				"alle": {
+					"type": "gaaTil",
+					"steg": "3.2"
+				}
+			}
+		},
+		{
+			"stegnr": "3.2",
+			"spm": "Er bilde til pynt/dekor eller brukt som bakgrunn eller til formatering?",
+			"ht": "Eksempel på slike bilde er usynlige bilde, gjennomsiktige bilde, pyntebilde og bord.",
+			"type": "jaNei",
+			"ruting": {
+				"ja": {
+					"type": "gaaTil",
+					"steg": "3.3"
+				},
+				"nei": {
+					"type": "gaaTil",
+					"steg": "3.10"
+				}
+			}
+		},
+		{
+			"stegnr": "3.3",
+			"spm": "Er bilde koda med eit eller fleire av attributta aria-label eller aria-labelledby?",
+			"ht": "Du kan nytte kodeverktøyet i nettlesaren til å sjekke dette. Attributta overstyrer eventuelt alt-attributt eller title-attributt, sjølv om attributta er tomme.",
+			"type": "jaNei",
+			"kilde": [
+				"ARIA6",
+				"ARIA10"
+			],
+			"ruting": {
+				"ja": {
+					"type": "avslutt",
+					"fasit": "Nei",
+					"utfall": "Bilde som er pynt/dekor/bakgrunn/formatering, er koda med attributta aria-label eller aria-labelledby."
+				},
+				"nei": {
+					"type": "gaaTil",
+					"steg": "3.4"
+				}
+			}
+		},
+		{
+			"stegnr": "3.4",
+			"spm": "Er bilde koda med attributtet role=\"presentation\"?",
+			"ht": "<p>Du kan nytte kodeverktøyet i nettlesaren til å sjekke dette.</p>",
+			"type": "jaNei",
+			"kilde": [
+				"F38"
+			],
+			"ruting": {
+				"ja": {
+					"type": "avslutt",
+					"fasit": "Ja",
+					"utfall": "Bilde som er pynt/dekor/bakgrunn/formatering, har tomt tekstalternativ."
+				},
+				"nei": {
+					"type": "gaaTil",
+					"steg": "3.5"
+				}
+			}
+		},
+		{
+			"stegnr": "3.5",
+			"spm": "Er bilde koda som &#x3C;img&#x3E;?",
+			"ht": "Du kan nytte kodeverktøyet i nettlesaren til å sjekke dette.",
+			"type": "jaNei",
+			"kilde": [
+				"H37"
+			],
+			"ruting": {
+				"ja": {
+					"type": "gaaTil",
+					"steg": "3.6"
+				},
+				"nei": {
+					"type": "gaaTil",
+					"steg": "3.8"
+				}
+			}
+		},
+		{
+			"stegnr": "3.6",
+			"spm": "Har bilde eit alt-attributt?",
+			"ht": "Du kan nytte kodeverktøyet i nettlesaren til å sjekke dette.",
+			"type": "jaNei",
+			"ruting": {
+				"ja": {
+					"type": "gaaTil",
+					"steg": "3.7"
+				},
+				"nei": {
+					"type": "avslutt",
+					"fasit": "Nei",
+					"utfall": "Bilde som er pynt/dekor/bakgrunn/formatering, manglar alt-attributt."
+				}
+			}
+		},
+		{
+			"stegnr": "3.7",
+			"spm": "Er alt-attributtet tomt?",
+			"ht": "Sjå i koden om alt-attributtet har innhald. Eit tomt alt-attributt er koda på formen <code>alt=\"\"</code> eller berre <code>alt</code>.",
+			"type": "jaNei",
+			"kilde": [
+				"H67",
+				"F38",
+				"F39"
+			],
+			"ruting": {
+				"ja": {
+					"type": "gaaTil",
+					"steg": "3.8"
+				},
+				"nei": {
+					"type": "avslutt",
+					"fasit": "Nei",
+					"utfall": "Bilde som er pynt/dekor/bakgrunn/formatering, har ikkje tomt alt-attributt."
+				}
+			}
+		},
+		{
+			"stegnr": "3.8",
+			"spm": "Har bilde eit title-attributt?",
+			"ht": "Du kan nytte kodeverktøyet i nettlesaren til å sjekke dette.",
+			"type": "jaNei",
+			"kilde": [
+				"F38"
+			],
+			"ruting": {
+				"ja": {
+					"type": "gaaTil",
+					"steg": "3.9"
+				},
+				"nei": {
+					"type": "avslutt",
+					"fasit": "Ja",
+					"utfall": "Bilde som er pynt/dekor/bakgrunn/formatering, har tomt tekstalternativ."
+				}
+			}
+		},
+		{
+			"stegnr": "3.9",
+			"spm": "Er title-attributtet tomt?",
+			"ht": "Sjå i koden om title-attributtet har innhald. Eit tomt title-attributt er koda på formen <code>title=\"\"</code> eller berre <code>title</code>.",
+			"type": "jaNei",
+			"kilde": [
+				"F38"
+			],
+			"ruting": {
+				"ja": {
+					"type": "avslutt",
+					"fasit": "Ja",
+					"utfall": "Bilde som er pynt/dekor/bakgrunn/formatering, har tomt tekstalternativ."
+				},
+				"nei": {
+					"type": "avslutt",
+					"fasit": "Nei",
+					"utfall": "Bilde som er pynt/dekor/bakgrunn/formatering, har ikkje tomt title-attributt."
+				}
+			}
+		},
+		{
+			"stegnr": "3.10",
+			"spm": "Har bilde attributtet \"aria-label\"?",
+			"ht": "<p>Du kan nytte kodeverktøyet i nettlesaren til å sjekke dette. Attributtet overstyrer eventuelt alt-attributt eller title-attributt. MERK: Du skal ikkje vurdere kvaliteten på teksten. Sjå i koden og finn det aktuelle <code>&#x3C;img&#x3E;</code>-elementet.</p><p> Eksempel: <code>&#x3C;img aria-label=\"Alternativ tekst\"&#x3E;</code></p>",
+			"type": "jaNei",
+			"kilde": [
+				"ARIA6",
+				"F65"
+			],
+			"ruting": {
+				"ja": {
+					"type": "gaaTil",
+					"steg": "3.19"
+				},
+				"nei": {
+					"type": "gaaTil",
+					"steg": "3.11"
+				}
+			}
+		},
+		{
+			"stegnr": "3.11",
+			"spm": "Har bilde attributtet \"aria-labelledby\" eller \"aria-describedby\"?",
+			"ht": "MERK: Du skal ikkje vurdere kvaliteten på teksten. Merk at ein aria-labelledby kan innhalde fleire id-ar i same attributt. Id-ane er skilt med mellomrom. (<code>Aria-labelledby=\"id1 id2\"</code>).",
+			"type": "jaNei",
+			"kilde": [
+				"ARIA10",
+				"ARIA15",
+				"F65"
+			],
+			"ruting": {
+				"ja": {
+					"type": "gaaTil",
+					"steg": "3.12"
+				},
+				"nei": {
+					"type": "gaaTil",
+					"steg": "3.13"
+				}
+			}
+		},
+		{
+			"stegnr": "3.12",
+			"spm": "Er aria-labelledby/aria-describedby attributtet kopla til annan tekst på sida?",
+			"ht": "<p>Gjer eit søk i koden på id i aria-labelledby. Dersom det finst fleire id-ar skal du undersøke alle. Id-ane vil då vere skilt med mellomrom. (Aria-labelledby=\"id1 id2\").</p>",
+			"type": "jaNei",
+			"kilde": [
+				"ARIA10",
+				"ARIA15",
+				"F65"
+			],
+			"ruting": {
+				"ja": {
+					"type": "gaaTil",
+					"steg": "3.19"
+				},
+				"nei": {
+					"type": "gaaTil",
+					"steg": "3.13"
+				}
+			}
+		},
+		{
+			"stegnr": "3.13",
+			"spm": "Er bilde koda med attributtet role=\"presentation\"?",
+			"ht": "Du kan nytte kodeverktøyet i nettlesaren til å sjekke dette.",
+			"type": "jaNei",
+			"kilde": [
+				"F38"
+			],
+			"ruting": {
+				"ja": {
+					"type": "avslutt",
+					"fasit": "Nei",
+					"utfall": "Meiningsberande bilde er koda med role=\"presentation\"."
+				},
+				"nei": {
+					"type": "gaaTil",
+					"steg": "3.14"
+				}
+			}
+		},
+		{
+			"stegnr": "3.14",
+			"spm": "Er bilde koda som &#x3C;img&#x3E;?",
+			"ht": "Du kan nytte kodeverktøyet i nettlesaren til å sjekke dette.",
+			"type": "jaNei",
+			"kilde": [
+				"H37"
+			],
+			"ruting": {
+				"ja": {
+					"type": "gaaTil",
+					"steg": "3.15"
+				},
+				"nei": {
+					"type": "gaaTil",
+					"steg": "3.17"
+				}
+			}
+		},
+		{
+			"stegnr": "3.15",
+			"spm": "Har bilde eit alt-attributt?",
+			"ht": "Du kan nytte kodeverktøyet i nettlesaren til å sjekke dette.",
+			"type": "jaNei",
+			"kilde": [
+				"H37",
+				"F65"
+			],
+			"ruting": {
+				"ja": {
+					"type": "gaaTil",
+					"steg": "3.16"
+				},
+				"nei": {
+					"type": "avslutt",
+					"fasit": "Nei",
+					"utfall": "Meiningsberande bilde manglar alt-attributt."
+				}
+			}
+		},
+		{
+			"stegnr": "3.16",
+			"spm": "Er det innhald i alt-attributtet?",
+			"ht": "<p>Sjå i koden om alt-attributtet har innhald. Eit tomt alt-attributt er koda på formen <code>alt=\"\"</code> eller berre <code>alt</code>.</p>",
+			"type": "jaNei",
+			"kilde": [
+				"H37"
+			],
+			"ruting": {
+				"ja": {
+					"type": "gaaTil",
+					"steg": "3.19"
+				},
+				"nei": {
+					"type": "gaaTil",
+					"steg": "3.17"
+				}
+			}
+		},
+		{
+			"stegnr": "3.17",
+			"spm": "Har bilde eit title-attributt?",
+			"ht": "Du kan nytte kodeverktøyet i nettlesaren til å sjekke dette.",
+			"type": "jaNei",
+			"kilde": [
+				"F65"
+			],
+			"ruting": {
+				"ja": {
+					"type": "gaaTil",
+					"steg": "3.18"
+				},
+				"nei": {
+					"type": "avslutt",
+					"fasit": "Nei",
+					"utfall": "Meiningsberande bilde manglar tekstalternativ."
+				}
+			}
+		},
+		{
+			"stegnr": "3.18",
+			"spm": "Er det innhald i title-attributtet?",
+			"ht": "Sjå i koden om title-attributtet har innhald. Eit tomt title-attributt er koda på formen title=\"\" eller berre title.",
+			"type": "jaNei",
+			"kilde": [
+				"F65"
+			],
+			"ruting": {
+				"ja": {
+					"type": "gaaTil",
+					"steg": "3.19"
+				},
+				"nei": {
+					"type": "avslutt",
+					"fasit": "Nei",
+					"utfall": "Meiningsberande bilde manglar tekstalternativ."
+				}
+			}
+		},
+		{
+			"stegnr": "3.19",
+			"spm": "Er bilde ein test eller ei sanseoppleving?",
+			"ht": "<p><b>Test: </b>Bilde som er ein del av ein test eller øving er bilde der innhaldet vil bli ugyldig dersom det blir presentert som tekst. Hensikten med testen vil forvinne dersom svaret blir avslørt av tekstalternativet.</p><p><b>Sanseoppleving: </b>Bilde som skal gi ei sanseoppleving er bilde som ikkje berre er til pynt, men som ikkje har som hovudformål å formidle informasjon. Eit maleri er eksempel på ei sanseoppleving.</p>",
+			"type": "jaNei",
+			"kilde": [
+				"G94",
+				"G100",
+				"F30"
+			],
+			"ruting": {
+				"ja": {
+					"type": "gaaTil",
+					"steg": "3.20"
+				},
+				"nei": {
+					"type": "gaaTil",
+					"steg": "3.21"
+				}
+			}
+		},
+		{
+			"stegnr": "3.20",
+			"spm": "Gir innhaldet i attributtet ein beskrivande identifikasjon av bilde?",
+			"ht": "<p>Gjer ei skjønnsmessig vurdering av om informasjonen i attributtet (dvs. tekstalternativet) identifiserer innhaldet i bilde. Viss aria-labelledby visar til dupliserte id-ar, skal du vurdere innhaldet til id-en som står først i koden.</p>\n<p><strong>Merk:</strong> Filnamn, kor tekstalternativet inneheld eit filetternamn som for eksempel .jpg eller .png, er alltid feil.</p>",
+			"type": "jaNei",
+			"kilde": [
+				"G94",
+				"G100",
+				"F30"
+			],
+			"ruting": {
+				"ja": {
+					"type": "avslutt",
+					"fasit": "Ja",
+					"utfall": "Bilde som er ei sanseoppleving eller ein test, har beskrivande tekstalternativ."
+				},
+				"nei": {
+					"type": "avslutt",
+					"fasit": "Nei",
+					"utfall": "Bilde som er ei sanseoppleving eller ein test, har ikkje beskrivande tekstalternativ."
+				}
+			}
+		},
+		{
+			"stegnr": "3.21",
+			"spm": "Gir innhaldet i attributtet den same informasjonen som er formidla av bilde?",
+			"ht": "<p>Gjer ei skjønnsmessig vurdering av om informasjonen i attributtet (dvs. tekstalternativet) gir tilstrekkeleg informasjon. Eit godt tekstalternativ gjer det mogleg å erstatte bilde med tekstalternativet uten å miste funksjonalitet eller informasjon. Viss aria-labelledby visar til dupliserte id-ar, skal du vurdere innhaldet til id-en som står først i koden. Merk: Filnamn, kor tekstalternativet inneheld eit filetternamn som for eksempel .jpg eller .png, er alltid feil.</p>",
+			"type": "jaNei",
+			"kilde": [
+				"F30",
+				"G94"
+			],
+			"ruting": {
+				"ja": {
+					"type": "gaaTil",
+					"steg": "3.22"
+				},
+				"nei": {
+					"type": "gaaTil",
+					"steg": "3.22"
+				}
+			}
+		},
+		{
+			"stegnr": "3.22",
+			"spm": "Er bilde komplekst?",
+			"ht": "Eksempel på komplekse bilde er grafar, diagram eller andre bilde som inneheld mykje informasjon.",
+			"type": "jaNei",
+			"kilde": [
+				"G95"
+			],
+			"ruting": {
+				"ja": {
+					"type": "gaaTil",
+					"steg": "3.23"
+				},
+				"nei": {
+					"type": "regler",
+					"regler": {
+						"1": {
+							"sjekk": "3.21",
+							"type": "lik",
+							"verdi": "Nei",
+							"handling": {
+								"type": "avslutt",
+								"fasit": "Nei",
+								"utfall": "Meiningsberande bilde har tekstalternativ som ikkje er beskrivande."
+							}
+						},
+						"2": {
+							"sjekk": "3.21",
+							"type": "lik",
+							"verdi": "Ja",
+							"handling": {
+								"type": "avslutt",
+								"fasit": "Ja",
+								"utfall": "Meiningsberande bilde har beskrivande tekstalternativ."
+							}
+						}
+					}
+				}
+			}
+		},
+		{
+			"stegnr": "3.23",
+			"spm": "Gir innhaldet i attributtet ein beskrivande identifikasjon av bilde?",
+			"ht": "Merk at vi her kun krever ein identifikasjon i det korte tekstalternativet til komplekse bilde. Gjer ei skjønnsmessig vurdering av om informasjonen i attributtet (dvs. tekstalternativet) identifiserer innhaldet i bilde. Viss aria-labelledby visar til dupliserte id-ar, skal du vurdere innhaldet til id-en som står først i koden. Filnamn, kor tekstalternativet inneheld eit filetternamn som for eksempel .jpg eller .png, er alltid feil.",
+			"type": "jaNei",
+			"kilde": [
+				"G95"
+			],
+			"ruting": {
+				"ja": {
+					"type": "gaaTil",
+					"steg": "3.24"
+				},
+				"nei": {
+					"type": "avslutt",
+					"fasit": "Nei",
+					"utfall": "Komplekst bilde har kort tekstalternativ som ikkje er beskrivande."
+				}
+			}
+		},
+		{
+			"stegnr": "3.24",
+			"spm": "Ligg det ein utfyllande tekst om bilde i direkte tilknytning til bilde?",
+			"ht": "Tekstalternativet er synlig for alle brukere og skal beskrive innhaldet i bilde. For å vere i direkte tilknytning, skal teksten ligge anten rett før eller rett etter bilde i koden.",
+			"type": "jaNei",
+			"kilde": [
+				"G74"
+			],
+			"ruting": {
+				"ja": {
+					"type": "gaaTil",
+					"steg": "3.29"
+				},
+				"nei": {
+					"type": "gaaTil",
+					"steg": "3.25"
+				}
+			}
+		},
+		{
+			"stegnr": "3.25",
+			"spm": "Viser attributtet på bilde til ein utfyllande tekst som ligg på same side som bilde?",
+			"ht": "Det korte tekstalternativet på bilde skal vise til kor brukaren kan finne et utfyllande tekstalternativ med meir informasjon.",
+			"type": "jaNei",
+			"kilde": [
+				"G74"
+			],
+			"ruting": {
+				"ja": {
+					"type": "gaaTil",
+					"steg": "3.29"
+				},
+				"nei": {
+					"type": "gaaTil",
+					"steg": "3.26"
+				}
+			}
+		},
+		{
+			"stegnr": "3.26",
+			"spm": "Ligg det ei lenke, i direkte tilknytning til bilde, som tek deg til ein utfyllande tekst om bilde?",
+			"ht": "For å vere i direkte tilknytning, skal teksten ligge anten rett før eller rett etter bilde i koden. Lenka kan peike til tekst som ligg på ei anna nettside, eller på same side som bilde.",
+			"type": "jaNei",
+			"kilde": [
+				"G73"
+			],
+			"ruting": {
+				"ja": {
+					"type": "gaaTil",
+					"steg": "3.29"
+				},
+				"nei": {
+					"type": "gaaTil",
+					"steg": "3.27"
+				}
+			}
+		},
+		{
+			"stegnr": "3.27",
+			"spm": "Er bilde koda med attributtet longdesc?",
+			"ht": "Du kan nytte kodeverktøyet i nettlesaren til å sjekke dette.",
+			"type": "jaNei",
+			"kilde": [
+				"H45"
+			],
+			"ruting": {
+				"ja": {
+					"type": "gaaTil",
+					"steg": "3.28"
+				},
+				"nei": {
+					"type": "avslutt",
+					"fasit": "Nei",
+					"utfall": "Komplekst bilde har ikkje kopling til langt tekstalternativ."
+				}
+			}
+		},
+		{
+			"stegnr": "3.28",
+			"spm": "Fungerer lenka som ligg i longdesc-attributtet?",
+			"ht": "Kopier URL som ligg i longdesc og opne i nettlesaren.",
+			"type": "jaNei",
+			"kilde": [
+				"H45"
+			],
+			"ruting": {
+				"ja": {
+					"type": "gaaTil",
+					"steg": "3.29"
+				},
+				"nei": {
+					"type": "avslutt",
+					"fasit": "Nei",
+					"utfall": "Komplekst bilde har ikkje kopling til langt tekstalternativ."
+				}
+			}
+		},
+		{
+			"stegnr": "3.29",
+			"spm": "Er tekstalternativet koda som tekst?",
+			"ht": "<p>Teksten kan vere løpande tekst, tabell eller lignande. Dette kan undersøkast på fleire måtar:</p>\n<ul>\n<li>Alternativ 1: Sjå om du får til å markere teksten med mus eller tastatur. Dette indikerer at teksten er koda som tekst og ikkje er eit bilde av tekst.</li>\n<li>Alternativ 2: Sjekk at tekstalternativet er koda som tekst, ved å sjå om du finn att teksten i koden.</li>\n</ul>",
+			"type": "jaNei",
+			"ruting": {
+				"ja": {
+					"type": "gaaTil",
+					"steg": "3.30"
+				},
+				"nei": {
+					"type": "avslutt",
+					"fasit": "Nei",
+					"utfall": "Komplekst bilde har langt tekstalternativ som ikkje er koda som tekst."
+				}
+			},
+			"kilde": []
+		},
+		{
+			"stegnr": "3.30",
+			"spm": "Gir innhaldet i den utfyllande teksten ei skildring av innhaldet i bilde?",
+			"ht": "<p>Gjer ei skjønnsmessig vurdering av om informasjonen i det utfyllande tekstalternativet gir tilstrekkeleg informasjon. Eit godt tekstalternativ gjer det mogleg å erstatte bilde med tekstalternativet uten å miste funksjonalitet eller informasjon.</p>",
+			"type": "jaNei",
+			"kilde": [
+				"F67",
+				"G92"
+			],
+			"ruting": {
+				"ja": {
+					"type": "avslutt",
+					"fasit": "Ja",
+					"utfall": "Komplekst bilde har beskrivande tekstalternativ."
+				},
+				"nei": {
+					"type": "avslutt",
+					"fasit": "Nei",
+					"utfall": "Bilde som er komplekst og som har eit langt tekstalternativ som ikkje gir ein utfyllande skildring av innhaldet i bilde."
+				}
+			}
+		}
+	]
+}


### PR DESCRIPTION
- longdesc er fjernet fra [HTML-specs](https://html.spec.whatwg.org/multipage/obsolete.html) og heller ikke støtter nåværende skjermlesere, derfor ble fjernet fra testregelen. Teknikken H45 er ikke gyldig lenger.
- Registrering av tekstalternativ har blitt lagt inn som et nytt steg.