### PR TITLE
nett 2.4.3a er klar for ks

### DIFF
--- a/Testreglar/2.4.3/Nett/nett-2.4.3a.json
+++ b/Testreglar/2.4.3/Nett/nett-2.4.3a.json
@@ -1,11 +1,11 @@
 {
-	"namn": "2.4.3a Tastaturekkefølgje ivaretek meiningsinnhald og betening",
-	"id": "2.4.3a",
-	"testlabId": 238,
+	"namn": "Nett-2.4.3a Tastaturekkefølgje ivaretar meiningsinnhald og betening 2023",
+	"id": "nett-2.4.3a",
+	"testlabId": 471,
 	"versjon": "1.0",
 	"type": "Nett",
 	"spraak": "nn",
-	"kravTilSamsvar": "<p>Kravet kan oppfyllast på fleire måtar.</p>\r\n<ul>\r\n<li>For innhald som får fokus ved tastaturnavigasjon og må navigerast i ei bestemt rekkefølgje, er eit av følgande oppfylt:\r\n<ul>\r\n<li>tastaturrekkefølgje og visuell rekkefølgje er like, eller</li>\r\n<li>tastaturrekkefølgja og visuell rekkefølgje er ikkje like, men det er mogleg å forstå og bruke innhaldet</li>\r\n</ul>\r\n</li>\r\n</ul>",
+	"kravTilSamsvar": "<p>For innhold som får fokus ved tastaturnavigasjon og må navigeres i en bestemt rekkefølge, er ett av følgende alternativ oppfylt:</p>\r\n<ul>\r\n<li>tastaturrekkefølge og visuell rekkefølge er lik eller</li>\r\n<li>tastaturrekkefølge og visuell rekkefølge er ulik, men det er likevel mulig å forstå og bruke innholdet</li>\r\n</ul>",
 	"side": "2.1",
 	"element": "3.1",
 	"kolonner": [
@@ -31,12 +31,11 @@
 	"steg": [
 		{
 			"stegnr": "2.1",
-			"spm": "Kva side testar du på?",
-			"ht": "Oppgi URL eller side-ID.",
+			"spm": "Kva side testar du?",
+			"ht": "<p>Angi URL eller side-ID.</p>",
 			"type": "tekst",
 			"label": "URL/Side:",
 			"datalist": "Sideutvalg",
-			"oblig": true,
 			"ruting": {
 				"alle": {
 					"type": "gaaTil",
@@ -46,8 +45,8 @@
 		},
 		{
 			"stegnr": "2.2",
-			"spm": "Får du synleg fokusmarkering ved tastaturnavigering?",
-			"ht": "<p>Trykk sakte på tabulatortasten (tab-tasten) for å navigere på nettsida med tastaturet.</p><p>Følg nøye med på navigasjonen og informasjonen i eventuell statuslinje for å orientere deg på nettsida.</p><p>Vi er avhengige av synleg fokusmarkør for å kunne gjennomføre testen. Synleg fokusmarkering blir testa på suksesskriterium 2.4.7.</p>",
+			"spm": "Får du synleg fokusmarkering ved tastaturnavigasjon?",
+			"ht": "<p>Slik testar du:</p>\n<ul>\n<li>Trykk sakte på tab-tasten for å navigere på nettsida med tastaturet.</li>\n<li>Følg nøye med på navigasjonen og informasjonen i eventuell statuslinje for å orientere deg på nettsida.</li>\n<li>Vi er avhengige av synleg fokusmarkør for å kunne gjennomføre testen. Synleg fokusmarkering blir testa på suksesskriterium 2.4.7.</li>\n</ul>",
 			"type": "jaNei",
 			"ruting": {
 				"ja": {
@@ -57,14 +56,14 @@
 				"nei": {
 					"type": "avslutt",
 					"fasit": "Ikkje testbart",
-					"utfall": "Testside har ikkje tilstrekkeleg fokusmarkering ved tastaturnavigasjon."
+					"utfall": "Testside har ikkje synleg fokusmarkering ved tastaturnavigasjon."
 				}
 			}
 		},
 		{
 			"stegnr": "2.3",
-			"spm": "Får du til å navigere på heile eller delar av nettsida med tastaturet?",
-			"ht": "<p>Trykk sakte på tabulatortasten (tab-tasten) for å navigere på nettsida med tastaturet. For å betene innhaldet kan du også bruke enter-tasten, mellomromstasten og piltastane. For å rygge med tastaturet, bruk Shift+Tab.</p><p>Det kan hende at du eventuelt må felle ut menyar og opne modalvindauge for å teste alt innhald på nettsida.</p>",
+			"spm": "Får du til å navigere på nettsida med tastaturet?",
+			"ht": "<p>Slik testar du:</p>\n<ul>\n<li>Trykk sakte på tab-tasten for å navigere på nettsida med tastaturet. \n<ul>\n<li>Følg nøye med på navigasjonen og informasjonen i statuslinja i nettlesaren</li>\n<li>For å betene innhaldet kan du også bruke enter, mellomrom og pil.</li>\n<li>For å rygge med tastaturet, bruk Shift+Tab.</li>\n</ul>\n</li>\n<li>Det kan vere at du må opne menyar og modaler for å teste alt innhald.</li>\n</ul>",
 			"type": "jaNei",
 			"ruting": {
 				"ja": {
@@ -73,14 +72,14 @@
 				},
 				"nei": {
 					"type": "ikkjeForekomst",
-					"utfall": "Testside har ikkje innhald/funksjonalitet som er mogleg å nå/betene med tastatur."
+					"utfall": "Testside har ikkje innhald eller funksjonalitet som er mogleg å nå eller betene med tastatur."
 				}
 			}
 		},
 		{
 			"stegnr": "2.4",
 			"spm": "Er tastaturrekkefølgja på nettsida den same som den visuelle rekkefølgja på innhaldet?",
-			"ht": "<p>Trykk sakte på tab-tasten for å navigere med tastaturet. Naviger frå starten av nettsida. Navigasjonen skal gå gjennom kvar enkelt blokk av innhald før den fortsetter vidare til neste blokk.</p><p>Det kan hende at du eventuelt må felle ut menyar og skjemafelt, og opne modalvindauge for å teste alt innhald på nettsida.</p><p>Merk: Ved opning av modalvindauge held navigasjonen  seg inne i vindauget. Etter lukking fortset navigeringa på elementet som opna modalvinduet, eller elementet som ligger direkte etterpå.</p><ul><li>Du skal berre teste innhald det er mogleg å nå med tastaturet.</li><li>Tastaturrekkefølgje er den rekkefølgja innhaldet får fokus i ved tastaturnavigering.</li><li>For å betene innhaldet kan du også bruke enter-tasten, mellomromstasten og piltastane. For å rygge med tastaturet, bruk Shift+Tab.</li></ul>",
+			"ht": "<p>Slik testar du</p>\n<ul>\n<li>Trykk sakte på tab-tasten for å navigere med tastaturet.</li>\n<li>Naviger frå starten av nettsida.</li>\n<li>Navigasjonen skal gå gjennom kvar enkelt blokk av innhald, før den fortsetter vidare til neste blokk.</li>\n<li>Det kan vere at du må opne menyar og modaler for å teste alt innhald.</li>\n</ul>\n<p><strong>Merk:</strong> Ved opning av modaler held navigasjonen seg inne i modalen. Etter lukking fortsetter navigasjonen på elementet som opna modalen, eller første element etter.</p>\n<ul>\n<li>Du skal berre teste innhald det er mogleg å nå med tastaturet.</li>\n<li>Tastaturrekkefølgje er den rekkefølgja innhaldet får fokus i ved tastaturnavigering.</li>\n<li>For å betene innhaldet kan du også bruke enter, mellomrom og pil.</li>\n<li>For å rygge med tastaturet, bruk Shift+Tab.</li>\n</ul>",
 			"type": "jaNei",
 			"kilde": [
 				"C27"
@@ -93,16 +92,16 @@
 				"ja": {
 					"type": "avslutt",
 					"fasit": "Ja",
-					"utfall": "Testside har tastaturrekkefølgje som er identisk med visuell rekkefølgje på innhaldet."
+					"utfall": "Testside har tastaturrekkefølgje som er identisk med visuell rekkefølgje."
 				}
 			}
 		},
 		{
 			"stegnr": "3.1",
-			"spm": "Beskriv innhaldet kor tastaturrekkefølgja er ulik.",
-			"ht": "Dersom det er fleire skal du skal registrere og legge til data for kvar enkelt observasjon. Legg inn overskrift, eller andre stikkord som er slik at innhaldet kan identifiserast.",
+			"spm": "Kva innhald har ulik tastaturrekkefølgje?",
+			"ht": "<p>Beskriv innhaldet, slik at det er mogleg å identifisere den i ettertid. </p>",
 			"type": "tekst",
-			"label": "Element:",
+			"label": "Innhald:",
 			"multilinje": true,
 			"oblig": true,
 			"ruting": {
@@ -114,14 +113,14 @@
 		},
 		{
 			"stegnr": "3.2",
-			"spm": "Kva type innhald er det ein del av?",
-			"ht": "Vel frå alternativa under.",
+			"spm": "Kva type funksjonalitet er innhaldet ein del av?",
+			"ht": "<p>Velg alternativ</p>",
 			"type": "radio",
 			"svarArray": [
 				"Skjema",
 				"Mediaspelar",
 				"Meny",
-				"Modalvindauge",
+				"Modal",
 				"Anna"
 			],
 			"ruting": {
@@ -133,14 +132,13 @@
 		},
 		{
 			"stegnr": "3.3",
-			"spm": "Må innhaldet vere i ei bestemt tastaturrekkefølgje for at du skal kunne forstå og bruke innhaldet?",
-			"ht": "<p>Meiningsinnhaldet skal ikkje vere endra, sjølv om rekkefølgja er ulik.</p><p>Eksempel der rekkefølgja påverker beteninga, er at fokusrekkefølgja navigerer gjennom alle skjemafelt før brukaren kjem til knappen for å sende inn.</p><p>Merk at det kan vere fleire rekkefølgjer som gir same mening.</p>",
+			"spm": "Må innhaldet ha ei bestemt tastaturrekkefølgje for at du skal kunne forstå og bruke innhaldet?",
+			"ht": "<p>Sjekk om meiningsinnhaldet blir påvirka av at rekkefølgja er ulik.</p>\n<p>Eksempel der rekkefølgja påvirker beteninga, er at fokusrekkefølgja navigerer gjennom alle skjemafelt før brukaren kjem til knappen for å sende inn.</p>\n<p><strong>Merk:</strong> Det kan vere fleire rekkefølgjer som gir same mening.</p>",
 			"type": "jaNei",
-			"kilde": [],
 			"ruting": {
 				"nei": {
 					"type": "ikkjeForekomst",
-					"utfall": "Testside har ikkje innhald som må navigerast i ei bestemt tastaturrekkefølgje for at det skal vere mogleg å forstå og bruke."
+					"utfall": "Innhaldet er mogleg å forstå og bruke, utan at det må navigerast i ei bestemt tastaturrekkefølgje."
 				},
 				"ja": {
 					"type": "gaaTil",
@@ -150,8 +148,8 @@
 		},
 		{
 			"stegnr": "3.4",
-			"spm": "Kan du forstå og bruke innhaldet, sjølv om tastaturrekkefølgja ikkje er lik den visuelle rekkefølgja?",
-			"ht": "Tastaturrekkefølgja treng ikkje vere identisk med den visuelle rekkefølgja, så lenge meiningsinnhald og betening er ivareteke.",
+			"spm": "Er det mogleg å forstå og bruke innhaldet, sjølv om tastaturrekkefølgja er ulik den visuelle rekkefølgja?",
+			"ht": "<p>Tastaturrekkefølgja treng ikkje vere identisk med den visuelle rekkefølgja, så lenge meiningsinnhald og betening er ivaretatt. </p>",
 			"type": "jaNei",
 			"kilde": [
 				"G59"
@@ -160,12 +158,12 @@
 				"ja": {
 					"type": "avslutt",
 					"fasit": "Ja",
-					"utfall": "Testside har tastaturrekkefølgje som er identisk med visuell rekkefølgje på innhaldet."
+					"utfall": "Testside har tastaturrekkefølgje som er identisk med visuell rekkefølgje."
 				},
 				"nei": {
 					"type": "avslutt",
 					"fasit": "Nei",
-					"utfall": "Testside har innhald det ikkje er mogeleg å forstå/bruke, fordi tastaturrekkefølgja ikkje er lik den visuelle rekkefølgja."
+					"utfall": "Testside har innhald det ikkje er mogeleg å forstå og bruke, fordi tastaturrekkefølgje er ulik den visuelle rekkefølgja."
 				}
 			}
 		}

--- a/Testreglar/2.4.3/Nett/nett-2.4.3a.json
+++ b/Testreglar/2.4.3/Nett/nett-2.4.3a.json
@@ -1,0 +1,173 @@
+{
+	"namn": "2.4.3a Tastaturekkefølgje ivaretek meiningsinnhald og betening",
+	"id": "2.4.3a",
+	"testlabId": 238,
+	"versjon": "1.0",
+	"type": "Nett",
+	"spraak": "nn",
+	"kravTilSamsvar": "<p>Kravet kan oppfyllast på fleire måtar.</p>\r\n<ul>\r\n<li>For innhald som får fokus ved tastaturnavigasjon og må navigerast i ei bestemt rekkefølgje, er eit av følgande oppfylt:\r\n<ul>\r\n<li>tastaturrekkefølgje og visuell rekkefølgje er like, eller</li>\r\n<li>tastaturrekkefølgja og visuell rekkefølgje er ikkje like, men det er mogleg å forstå og bruke innhaldet</li>\r\n</ul>\r\n</li>\r\n</ul>",
+	"side": "2.1",
+	"element": "3.1",
+	"kolonner": [
+		{
+			"title": "2.2"
+		},
+		{
+			"title": "2.3"
+		},
+		{
+			"title": "2.4"
+		},
+		{
+			"title": "3.2"
+		},
+		{
+			"title": "3.3"
+		},
+		{
+			"title": "3.4"
+		}
+	],
+	"steg": [
+		{
+			"stegnr": "2.1",
+			"spm": "Kva side testar du på?",
+			"ht": "Oppgi URL eller side-ID.",
+			"type": "tekst",
+			"label": "URL/Side:",
+			"datalist": "Sideutvalg",
+			"oblig": true,
+			"ruting": {
+				"alle": {
+					"type": "gaaTil",
+					"steg": "2.2"
+				}
+			}
+		},
+		{
+			"stegnr": "2.2",
+			"spm": "Får du synleg fokusmarkering ved tastaturnavigering?",
+			"ht": "<p>Trykk sakte på tabulatortasten (tab-tasten) for å navigere på nettsida med tastaturet.</p><p>Følg nøye med på navigasjonen og informasjonen i eventuell statuslinje for å orientere deg på nettsida.</p><p>Vi er avhengige av synleg fokusmarkør for å kunne gjennomføre testen. Synleg fokusmarkering blir testa på suksesskriterium 2.4.7.</p>",
+			"type": "jaNei",
+			"ruting": {
+				"ja": {
+					"type": "gaaTil",
+					"steg": "2.3"
+				},
+				"nei": {
+					"type": "avslutt",
+					"fasit": "Ikkje testbart",
+					"utfall": "Testside har ikkje tilstrekkeleg fokusmarkering ved tastaturnavigasjon."
+				}
+			}
+		},
+		{
+			"stegnr": "2.3",
+			"spm": "Får du til å navigere på heile eller delar av nettsida med tastaturet?",
+			"ht": "<p>Trykk sakte på tabulatortasten (tab-tasten) for å navigere på nettsida med tastaturet. For å betene innhaldet kan du også bruke enter-tasten, mellomromstasten og piltastane. For å rygge med tastaturet, bruk Shift+Tab.</p><p>Det kan hende at du eventuelt må felle ut menyar og opne modalvindauge for å teste alt innhald på nettsida.</p>",
+			"type": "jaNei",
+			"ruting": {
+				"ja": {
+					"type": "gaaTil",
+					"steg": "2.4"
+				},
+				"nei": {
+					"type": "ikkjeForekomst",
+					"utfall": "Testside har ikkje innhald/funksjonalitet som er mogleg å nå/betene med tastatur."
+				}
+			}
+		},
+		{
+			"stegnr": "2.4",
+			"spm": "Er tastaturrekkefølgja på nettsida den same som den visuelle rekkefølgja på innhaldet?",
+			"ht": "<p>Trykk sakte på tab-tasten for å navigere med tastaturet. Naviger frå starten av nettsida. Navigasjonen skal gå gjennom kvar enkelt blokk av innhald før den fortsetter vidare til neste blokk.</p><p>Det kan hende at du eventuelt må felle ut menyar og skjemafelt, og opne modalvindauge for å teste alt innhald på nettsida.</p><p>Merk: Ved opning av modalvindauge held navigasjonen  seg inne i vindauget. Etter lukking fortset navigeringa på elementet som opna modalvinduet, eller elementet som ligger direkte etterpå.</p><ul><li>Du skal berre teste innhald det er mogleg å nå med tastaturet.</li><li>Tastaturrekkefølgje er den rekkefølgja innhaldet får fokus i ved tastaturnavigering.</li><li>For å betene innhaldet kan du også bruke enter-tasten, mellomromstasten og piltastane. For å rygge med tastaturet, bruk Shift+Tab.</li></ul>",
+			"type": "jaNei",
+			"kilde": [
+				"C27"
+			],
+			"ruting": {
+				"nei": {
+					"type": "gaaTil",
+					"steg": "3.1"
+				},
+				"ja": {
+					"type": "avslutt",
+					"fasit": "Ja",
+					"utfall": "Testside har tastaturrekkefølgje som er identisk med visuell rekkefølgje på innhaldet."
+				}
+			}
+		},
+		{
+			"stegnr": "3.1",
+			"spm": "Beskriv innhaldet kor tastaturrekkefølgja er ulik.",
+			"ht": "Dersom det er fleire skal du skal registrere og legge til data for kvar enkelt observasjon. Legg inn overskrift, eller andre stikkord som er slik at innhaldet kan identifiserast.",
+			"type": "tekst",
+			"label": "Element:",
+			"multilinje": true,
+			"oblig": true,
+			"ruting": {
+				"alle": {
+					"type": "gaaTil",
+					"steg": "3.2"
+				}
+			}
+		},
+		{
+			"stegnr": "3.2",
+			"spm": "Kva type innhald er det ein del av?",
+			"ht": "Vel frå alternativa under.",
+			"type": "radio",
+			"svarArray": [
+				"Skjema",
+				"Mediaspelar",
+				"Meny",
+				"Modalvindauge",
+				"Anna"
+			],
+			"ruting": {
+				"alle": {
+					"type": "gaaTil",
+					"steg": "3.3"
+				}
+			}
+		},
+		{
+			"stegnr": "3.3",
+			"spm": "Må innhaldet vere i ei bestemt tastaturrekkefølgje for at du skal kunne forstå og bruke innhaldet?",
+			"ht": "<p>Meiningsinnhaldet skal ikkje vere endra, sjølv om rekkefølgja er ulik.</p><p>Eksempel der rekkefølgja påverker beteninga, er at fokusrekkefølgja navigerer gjennom alle skjemafelt før brukaren kjem til knappen for å sende inn.</p><p>Merk at det kan vere fleire rekkefølgjer som gir same mening.</p>",
+			"type": "jaNei",
+			"kilde": [],
+			"ruting": {
+				"nei": {
+					"type": "ikkjeForekomst",
+					"utfall": "Testside har ikkje innhald som må navigerast i ei bestemt tastaturrekkefølgje for at det skal vere mogleg å forstå og bruke."
+				},
+				"ja": {
+					"type": "gaaTil",
+					"steg": "3.4"
+				}
+			}
+		},
+		{
+			"stegnr": "3.4",
+			"spm": "Kan du forstå og bruke innhaldet, sjølv om tastaturrekkefølgja ikkje er lik den visuelle rekkefølgja?",
+			"ht": "Tastaturrekkefølgja treng ikkje vere identisk med den visuelle rekkefølgja, så lenge meiningsinnhald og betening er ivareteke.",
+			"type": "jaNei",
+			"kilde": [
+				"G59"
+			],
+			"ruting": {
+				"ja": {
+					"type": "avslutt",
+					"fasit": "Ja",
+					"utfall": "Testside har tastaturrekkefølgje som er identisk med visuell rekkefølgje på innhaldet."
+				},
+				"nei": {
+					"type": "avslutt",
+					"fasit": "Nei",
+					"utfall": "Testside har innhald det ikkje er mogeleg å forstå/bruke, fordi tastaturrekkefølgja ikkje er lik den visuelle rekkefølgja."
+				}
+			}
+		}
+	]
+}

--- a/Testreglar/2.4.3/Nett/nett-2.4.3a.json
+++ b/Testreglar/2.4.3/Nett/nett-2.4.3a.json
@@ -8,26 +8,6 @@
 	"kravTilSamsvar": "<p>For innhold som får fokus ved tastaturnavigasjon og må navigeres i en bestemt rekkefølge, er ett av følgende alternativ oppfylt:</p>\r\n<ul>\r\n<li>tastaturrekkefølge og visuell rekkefølge er lik eller</li>\r\n<li>tastaturrekkefølge og visuell rekkefølge er ulik, men det er likevel mulig å forstå og bruke innholdet</li>\r\n</ul>",
 	"side": "2.1",
 	"element": "3.1",
-	"kolonner": [
-		{
-			"title": "2.2"
-		},
-		{
-			"title": "2.3"
-		},
-		{
-			"title": "2.4"
-		},
-		{
-			"title": "3.2"
-		},
-		{
-			"title": "3.3"
-		},
-		{
-			"title": "3.4"
-		}
-	],
 	"steg": [
 		{
 			"stegnr": "2.1",


### PR DESCRIPTION
Apper: Vi legger til grunn at apper er utenfor kjernedekning for 2.4.3, da fokusrekkefølge ikke kan testes uten eksternt tastatur. I tillegg er det å koble til eksternt tastatur ikke en særlig vanlig bruksmåte for apper, selv om noen bruker det med nettbrett. Vi har ikke prioritert å lage testregel for apper. 