### PR TITLE
Testregelformat - Fjernet Kolonner

### DIFF
--- a/Doc/Testregelformat/Testregelformat.md
+++ b/Doc/Testregelformat/Testregelformat.md
@@ -11,7 +11,6 @@ Generell info om testreglar
 - Språk
 - Side
 - Element
-- Kolonner
 
 ## Namn
 Namn på testregel.
@@ -75,21 +74,6 @@ Dersom det er sida som er elementet skriv "Side"
 ### Eksempel
 ```json
 "element": "2.1"
-```
-
-## Kolonner
-Kva steg som skal visast i resultat-tabellen.
-### Eksempel
-```json
-"kolonner": [
-        {
-            "title": "2.2"
-        },
-        
-        {
-            "title": "3.2"
-        }
-        ]
 ```
 
 Steg

--- a/Tests/format.test.ts
+++ b/Tests/format.test.ts
@@ -81,7 +81,5 @@ type Testregel = {
     kravTilSamsvar: string;
     side: string;
     element: string;
-    kolonner: Array<string>;
     steg: Array<object>;
-
 }

--- a/Tests/format.test.ts
+++ b/Tests/format.test.ts
@@ -58,9 +58,6 @@ function sjekk_format(file:string): boolean {
             } else if (typeof (testregel.namn) !== "string") {
                 console.log("Filen " + file + " mangler feltet namn");
                 return false
-            } else if (!Array.isArray(testregel.kolonner)) {
-                console.log("Filen " + file + " mangler feltet kolonner");
-                return false
             } else if (!Array.isArray(testregel.steg)) {
                 console.log("Filen " + file + " mangler feltet steg");
                 return false


### PR DESCRIPTION
Fjernet "kolonner" fra Testregelformat. Vil kalkuleres i Testmotor.

Ref #306 