### PR TITLE
fix: Oppdater test og fjernet . fra namnet til 1.3.2a

### DIFF
--- a/Testreglar/1.3.2/Nett/1.3.2a.json
+++ b/Testreglar/1.3.2/Nett/1.3.2a.json
@@ -1,5 +1,5 @@
 {
-	"namn": "1.3.2a Meiningsfylt leserekkefølge er ivareteken i koden.",
+	"namn": "1.3.2a Meiningsfylt leserekkefølge er ivareteken i koden",
 	"id": "1.3.2a",
 	"testlabId": 235,
 	"versjon": "1.0",

--- a/Tests/format.test.ts
+++ b/Tests/format.test.ts
@@ -33,6 +33,10 @@ files.forEach((file) => {
     expect(/\s+$/.test(testregel.namn)).toBeFalsy();
   });
 
+  test(`${file} har eit namn som ikkje slutter på punktum`, () => {
+    expect(testregel.namn.endsWith(".")).toBeFalsy();
+  });
+
   test(`${file} har definert ein id`, () => {
     expect(testregel.id).toBeDefined();
     expect(testregel.id.length).toBeGreaterThan(0);


### PR DESCRIPTION
- Oppdatert test til å sjekke for testregelnamn som slutter med punktum.
- Fjernet punktum fra namnet til 1.3.2a