### PR TITLE
Nett-1.1.1b Formål med lenkede bilder går frem av lenketekst eller te…

### DIFF
--- a/Testreglar/1.1.1/Nett/111b2025.json
+++ b/Testreglar/1.1.1/Nett/111b2025.json
@@ -1,0 +1,158 @@
+{
+    "namn": "Nett-1.1.1b Formål med lenkede bilder går frem av lenketekst eller tekstalternativ 2025",
+    "id": "111b2025",
+    "testlabId": 548,
+    "versjon": "1.0",
+    "type": "Nett",
+    "spraak": "nb",
+    "kravTilSamsvar": "<p>Informasjon om lenkemålet for et lenket bilde går frem av ett av følgende alternativer</p><ul><li>lenketeksten til bildet</li><li>tekstalternativet til bildet</li><li>lenketeksten kombinert med tekstalternativet til bildet</li><li>tittel-attributtet til bildet</li></ul>",
+    "side": "2.1",
+    "element": "3.1",
+    "steg": [
+        {
+            "stegnr": "2.1",
+            "spm": "Hvilken side tester du?",
+            "ht": "<p>Angi URL eller side-ID.</p>",
+            "type": "tekst",
+            "label": "URL/Side:",
+            "datalist": "Sideutvalg",
+            "ruting": {
+                "alle": {
+                    "type": "gaaTil",
+                    "steg": "2.2"
+                }
+            }
+        },
+        {
+            "stegnr": "2.2",
+            "spm": "Finnes det lenkede bilder på testsiden?",
+            "ht": "<ul><li>Før musepekeren over bilder på nettsiden og se om markøren viser at bilder er klikkbare ved å endre seg (for eksempel til en hånd) eller</li><li>Bruke Inspiser i nettleseren for å søke etter a-elementet i HTML. Du skal teste lenker, <code>&lt;a&gt;</code>-elementet, som:<ul><li>Bare er et bilde.</li><li>Inneholder både bilde og tekst.</li><li>Inneholder ikon.</li></ul></li></ul><p><strong>Merk:</strong> Lenkens plassering har ikke betydning. Den kan for eksempel ligge i en meny, liste, tabell eller lignende. </p><p><strong>Merk:</strong> Du skal ikke teste:</p><ul><li>Knapper som er kodet som <code>&lt;input&gt;</code> og <code>&lt;button&gt;</code>.</li><li>Lenkende bilder som er del av Captcha.</li></ul>",
+            "type": "jaNei",
+            "ruting": {
+                "ja": {
+                    "type": "gaaTil",
+                    "steg": "3.1"
+                },
+                "nei": {
+                    "type": "ikkjeForekomst",
+                    "utfall": "Testsiden har ikke lenkede bilder."
+                }
+            },
+            "kilde": [
+                "H30"
+            ]
+        },
+        {
+            "stegnr": "3.1",
+            "spm": "Hvilket bilde tester du?",
+            "ht": "<p><strong>Bruk format:</strong></p><ul><li>Beskriv bildet</li><li>Beskriv plassering</li></ul><p><strong>Merk</strong>: Hvis det er flere bilder på siden, registrerer du ett og ett bilde.</p>",
+            "type": "tekst",
+            "label": "Bilde:",
+            "multilinje": true,
+            "ruting": {
+                "alle": {
+                    "type": "gaaTil",
+                    "steg": "3.2"
+                }
+            }
+        },
+        {
+            "stegnr": "3.2",
+            "spm": "Åpne lenken i en ny fane og registrer URL.",
+            "ht": "",
+            "type": "tekst",
+            "label": "URL:",
+            "multilinje": true,
+            "ruting": {
+                "alle": {
+                    "type": "gaaTil",
+                    "steg": "3.3"
+                }
+            }
+        },
+        {
+            "stegnr": "3.3",
+            "spm": "Har det lenkede bildet et tilgjengelig navn?",
+            "ht": "<ul><li>Gå tilbake til testsiden</li><li>Inspiser lenken. du skal finne og inspisere <code>&lt;a&gt;</code>-elementet som er knyttet til bildet.</li><li>Under Computed Properties i Accessibility Tree, sjekk at \"Name\" ikke er tomt.</li></ul><p> </p>",
+            "type": "jaNei",
+            "ruting": {
+                "ja": {
+                    "type": "gaaTil",
+                    "steg": "3.4"
+                },
+                "nei": {
+                    "type": "avslutt",
+                    "fasit": "Nei",
+                    "utfall": "Lenket bilde har ikke tilgjengelig navn."
+                }
+            }
+        },
+        {
+            "stegnr": "3.4",
+            "spm": "Hva er det lenkede bildet sitt tilgjengelig navn?",
+            "ht": "<p>Kopier innholdet i attributtet \"Name\" under Computed Properties i Accessibility Tree.</p>",
+            "type": "tekst",
+            "label": "Tekstalternativ:",
+            "multilinje": true,
+            "ruting": {
+                "alle": {
+                    "type": "gaaTil",
+                    "steg": "3.5"
+                }
+            }
+        },
+        {
+            "stegnr": "3.5",
+            "spm": "Hvilket attributt gir tilgjengelig navn til lenken?",
+            "ht": "<p>Sjekk dette under \"Name\" under Computed Properties i Accessibility Tree.</p>",
+            "type": "radio",
+            "svarArray": [
+                "aria-labelledby",
+                "aria-label",
+                "lenketekst eller tekstalternativ  (contents)",
+                "title"
+            ],
+            "ruting": {
+                "alle": {
+                    "type": "gaaTil",
+                    "steg": "3.6"
+                }
+            },
+            "kilde": [
+                "ARIA6",
+                "ARIA7",
+                "ARIA8",
+                "ARIA10",
+                "F65",
+                "H30",
+                "H37"
+            ]
+        },
+        {
+            "stegnr": "3.6",
+            "spm": "Er innholdet i det tilgjengelige navnet, beskrivende for lenkemålet?",
+            "ht": "<p>Gjør en skjønnsmessig vurdering av om innholdet i det tilgjengelige navnet, gir tilstrekkelig informasjon om hva som er lenkemålet. Lenkemålet er dit brukeren kommer ved å aktivere lenken. </p>",
+            "type": "jaNei",
+            "ruting": {
+                "ja": {
+                    "type": "avslutt",
+                    "fasit": "Ja",
+                    "utfall": "Lenket bilde har beskrivende tilgjengelig navn."
+                },
+                "nei": {
+                    "type": "avslutt",
+                    "fasit": "Nei",
+                    "utfall": "Lenket bilde har ikke beskrivende tilgjengelig navn."
+                }
+            },
+            "kilde": [
+                "ARIA7",
+                "ARIA8",
+                "F30",
+                "F89",
+                "G82",
+                "G94"
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
111bnett2025
Generelt: Merk: Navn er forenklet veldig, det er ikke lenger samsvar med spørsmål og svar men er praktisk enkelt. Dette blir vurdert videre etter statistisk gjennomgang og testing.
Generelt: Hjelpetekster er totalt endret. Det er ikke lenger «fakta» om testingen i tester, fremgangsmåter og viktig informasjon er bevart.
2.2 Fjernet to kulepunkt da dette allerede er implisitt i kravet
3.2 Fjernet hjelpetekst da den bare doblet opp informasjon
3.5 lenketekst eller tekstalternativ (contents), contents er lagt til for å gjenspeile Accessibility Tree
3.6 Merk: Hvis det ligger flere bilder i en og samme lenke, vurderer du tekstalternativene samlet.: fjernet, dette er vel aldri relevant.
