### PR TITLE
App-1.1.1a Bilde har tekstalternativ 2025

### DIFF
--- a/Testreglar/1.1.1/App/app111a2025.json
+++ b/Testreglar/1.1.1/App/app111a2025.json
@@ -1,0 +1,293 @@
+{
+    "namn": "App-1.1.1a Bilde har tekstalternativ 2025",
+    "id": "app111a2025",
+    "testlabId": 551,
+    "versjon": "1.0",
+    "type": "App",
+    "spraak": "nb",
+    "kravTilSamsvar": "<p>For ikke-lenkede bilder er ett av følgende punkter oppfylt:</p><ul><li>Bilder som er meningsbærende, har et kort tekstalternativ som gir same informasjon som bildet eller</li><li>Komplekse, meningsbærende bilder, har både et kort og et langt tekstalternativ som gir samme informasjon som bildet og<ul><li>Korte tekstalternativ har informasjon om plasseringen av langt tekstalternativ og</li><li>Bildet er programmatisk knyttet til langt tekstalternativ og</li><li>Langt tekstalternativ er kodet som tekst eller</li></ul></li><li>Ikke-tekstlig innhold som er en test, har kort tekstalternativ med en beskrivende identifikasjon av testen eller </li><li>Bilder der formålet er å skape et spesifikt sanseinntrykk, har tekstalternativ med en beskrivende identifikasjon av bildet eller </li><li>Bilder som er ren dekorasjon, brukes utelukkende til visuell formatering eller ikke presenteres for brukerne, kodes det slik at det kan ignoreres av hjelpemiddelteknologi</li></ul>",
+    "side": "2.1",
+    "element": "3.1",
+    "steg": [
+        {
+            "stegnr": "2.1",
+            "spm": "Hvilken appside tester du?",
+            "ht": "<p>Beskriv appsiden med få stikkord, eller velg i listen.</p>",
+            "type": "tekst",
+            "label": "Appside:",
+            "datalist": "Sideutvalg",
+            "ruting": {
+                "alle": {
+                    "type": "gaaTil",
+                    "steg": "2.2"
+                }
+            }
+        },
+        {
+            "stegnr": "2.2",
+            "spm": "Finnes det ikke-lenkede bilder på appsiden?",
+            "ht": "",
+            "type": "jaNei",
+            "ruting": {
+                "ja": {
+                    "type": "gaaTil",
+                    "steg": "2.3"
+                },
+                "nei": {
+                    "type": "ikkjeForekomst",
+                    "utfall": "Appsiden har ingen ikke-lenkede bilder."
+                }
+            }
+        },
+        {
+            "stegnr": "2.3",
+            "spm": "Er bildet omfattet av kravene?",
+            "ht": "<p><strong>Unntak</strong>:</p><ul><li><strong>Nettbaserte kart og karttjenester</strong> er som hovedregel unntatt kravene til universell utforming. <br><ul><li><strong>Merk:</strong> For kart ment for navigasjonsformål skal likevel nødvendig informasjon være tilgjengelig på en annen måte. Dette kan for eksempel være et kart som viser besøksadressen til offentlige virksomheter eller en oversikt over stoppesteder for kollektivtransport</li></ul></li><li><strong>Tegneserier,</strong> eller tegnede bilder i en bevisst rekkefølge, formidler informasjon eller skaper en opplevelse, er som hovedregel unntatt kravene til universell utforming. </li><li style=\"list-style-type: none;\"><ul><li><strong>Merk:</strong> Kortere formater, som enkeltpanel og tegneseriestriper er likevel omfattet.</li></ul></li></ul>",
+            "type": "jaNei",
+            "ruting": {
+                "ja": {
+                    "type": "gaaTil",
+                    "steg": "2.4"
+                },
+                "nei": {
+                    "type": "ikkjeForekomst",
+                    "utfall": "Det finnes ikke-lenkede bilder på appsiden, disse er ikke omfattet av kravet."
+                }
+            }
+        },
+        {
+            "stegnr": "2.4",
+            "spm": "Er det mulig å sveipe til minst et bilde på appsiden?",
+            "ht": "<ul><li>aktiver skjermleser<ul><li>iOS: VoiceOver</li><li>Android: Talkback</li></ul></li><li>åpne appsiden</li><li>forsøk å sveipe til bildet</li></ul>",
+            "type": "jaNei",
+            "ruting": {
+                "ja": {
+                    "type": "gaaTil",
+                    "steg": "3.1"
+                },
+                "nei": {
+                    "type": "avslutt",
+                    "fasit": "Ikkje testbart",
+                    "utfall": "Det er ikke mulig å sveipe til bilder på appsiden."
+                }
+            }
+        },
+        {
+            "stegnr": "3.1",
+            "spm": "Hvilket bilde tester du?",
+            "ht": "<p><strong>Bruk format:</strong></p><ul><li>Beskriv bildet</li><li>Beskriv plassering</li></ul><p><strong>Merk:</strong> Hvis det er flere bilder på siden, registrerer du ett og ett bilde.</p>",
+            "type": "tekst",
+            "ruting": {
+                "alle": {
+                    "type": "gaaTil",
+                    "steg": "3.2"
+                }
+            },
+            "label": "Bilde:",
+            "multilinje": true
+        },
+        {
+            "stegnr": "3.2",
+            "spm": "Er bildet ren dekorasjon?",
+            "ht": "<p><strong>Ren dekorasjon:</strong> Der bildet ikke gir mer informasjon eller funksjonalitet enn tekst som hører til bildet, er bildet vanligvis dekorativt. Dette gjelder eksempelvis et bilde i en artikkel hvor bildet er beskrevet i tekst eller en bølge over nettsiden som skaper en visuell effekt.</p><p><strong>Merk:</strong> Portrettbilder er vanligvis dekorative.</p>",
+            "type": "jaNei",
+            "ruting": {
+                "nei": {
+                    "type": "gaaTil",
+                    "steg": "3.4"
+                },
+                "ja": {
+                    "type": "gaaTil",
+                    "steg": "3.3"
+                }
+            },
+            "kilde": [
+                "wcag:ordliste"
+            ]
+        },
+        {
+            "stegnr": "3.3",
+            "spm": "Er bildet kodet slik at det kan ignoreres av hjelpemiddelteknologi?",
+            "ht": "<ul><li>Skru av AI gjenkjenning av bilder(automatisk tekstalternativ) <br>(Innstillinger &gt; Tilgjengelighet &gt; VoiceOver &gt; VoiceOver-gjenkjenning &gt; Bildebeskrivelser Av)</li><li>aktiver skjermleser</li><li>sveip og trykk på bildet du tester</li><li>sjekk at skjermleser ikke leser opp informasjon når du trykker på bildet</li></ul><p> </p>",
+            "type": "jaNei",
+            "ruting": {
+                "ja": {
+                    "type": "avslutt",
+                    "fasit": "Ja",
+                    "utfall": "Bilde som er ren dekorasjon, brukes utelukkende til visuell formatering eller ikke presenteres for brukerne, er kodet slik at det ignoreres av hjelpemiddelteknologi."
+                },
+                "nei": {
+                    "type": "avslutt",
+                    "fasit": "Nei",
+                    "utfall": "Bilde som er ren dekorasjon, brukes utelukkende til visuell formattering eller ikke presenteres for brukerne, er kodet slik at det ikke ignoreres av hjelpemiddelteknologi."
+                }
+            }
+        },
+        {
+            "stegnr": "3.4",
+            "spm": "Har bildet et tilgjengelig navn?",
+            "ht": "<ul><li>aktiver skjermleser</li><li>sveip og trykk på bildet du tester</li><li>sjekk at skjermleser leser opp tekstalternativ (tilgjengelig navn) når du trykker på bildet</li></ul><p> </p>",
+            "type": "jaNei",
+            "ruting": {
+                "ja": {
+                    "type": "gaaTil",
+                    "steg": "3.5"
+                },
+                "nei": {
+                    "type": "avslutt",
+                    "fasit": "Nei",
+                    "utfall": "Meningsbærende bilde har ikke et tekstalternativ."
+                }
+            }
+        },
+        {
+            "stegnr": "3.5",
+            "spm": "Hvilket tekstalternativ tester du?",
+            "ht": "<p>Registrer tekstalternativet du fant i forrige steg.</p>",
+            "type": "tekst",
+            "label": "Tekstalternativet:",
+            "multilinje": true,
+            "ruting": {
+                "alle": {
+                    "type": "gaaTil",
+                    "steg": "3.6"
+                }
+            }
+        },
+        {
+            "stegnr": "3.6",
+            "spm": "Er det meningsbærende bildet en test eller et sanseinntrykk?",
+            "ht": "<p><strong>Test:</strong> Bilde som er en del av en test eller prøve, er bilde der innholdet vil bli ugyldig dersom det blir presentert som tekst. Hensikten med testen forsvinner dersom svaret gis av tekstalternativet.</p><p><strong>Sanseinntrykk:</strong> Bilde som skal gi et sanseinntrykk er for eksempel et maleri eller andre typer kunst.</p>",
+            "type": "jaNei",
+            "ruting": {
+                "ja": {
+                    "type": "gaaTil",
+                    "steg": "3.7"
+                },
+                "nei": {
+                    "type": "gaaTil",
+                    "steg": "3.8"
+                }
+            }
+        },
+        {
+            "stegnr": "3.7",
+            "spm": "Gir tekstalternativet beskrivende identifikasjon av bildet?",
+            "ht": "<ul><li>Tekstalternativet skal gi en beskrivende identifikasjon av det ikke-tekstlige innholdet,</li><li>Gjør en skjønnsmessig vurdering av om det tilgjengelige navnet identifiserer bildet,</li></ul><p><strong>Test:</strong></p><p>For eksempel: En oppgave som viser et bilde av analog klokke med tidspunkt kl. 14.30 som skal brukes til å svare spørsmål \"Hvor mye er klokken?\"<br>Tekstalternativ kan være: \"En klokke viser at den korte timeviseren er halvveis mellom 2 og 3. Den lange minuttviseren peker på 6.\"</p><p><br><strong>Sanseinntrykk:</strong></p><p>For eksempel: Bilde av en solnedgang over havet, dette bildet kan formidle en visuell opplevelse av varme farger, et mykt lys og en rolig atmosfære<br>Tekstalternativ kan være: \"En fredelig skogsti om høsten under solnedgangen, dekket av gyllent løv og omgitt av trær i varme farger, som skaper en rolig og harmonisk stemning\"</p><p> </p>",
+            "type": "jaNei",
+            "ruting": {
+                "ja": {
+                    "type": "avslutt",
+                    "fasit": "Ja",
+                    "utfall": "Meningsbærende bilde, som er en test eller et sanseinntrykk, har tekstalternativ som identifiserer at bildet er en test eller et sanseinntrykk."
+                },
+                "nei": {
+                    "type": "avslutt",
+                    "fasit": "Nei",
+                    "utfall": "Meningsbærende bilde, som er en test eller et sanseinntrykk, har tekstalternativ som ikke identifiserer at bildet er en test eller et sanseinntrykk."
+                }
+            }
+        },
+        {
+            "stegnr": "3.8",
+            "spm": "Gir det tilgjengelige navnet den samme informasjonen som er formidlet av bildet?",
+            "ht": "<p>Gjør en skjønnsmessig vurdering av om det tilgjengelige navnet du fant i forrige steg gir tilstrekkelig informasjon.</p>",
+            "type": "jaNei",
+            "ruting": {
+                "alle": {
+                    "type": "gaaTil",
+                    "steg": "3.9"
+                }
+            }
+        },
+        {
+            "stegnr": "3.9",
+            "spm": "Er bildet komplekst?",
+            "ht": "<p>Komplekse bilder inneholder mye informasjon til brukeren, for eksempel:</p><ul><li>Prosess-diagram</li><li>Fysikk-diagram som viser kinetisk energi</li><li>Illustrasjon av hvordan en bilmotor fungerer</li><li>Diagram over cellestruktur</li></ul>",
+            "type": "jaNei",
+            "ruting": {
+                "ja": {
+                    "type": "gaaTil",
+                    "steg": "3.10"
+                },
+                "nei": {
+                    "type": "regler",
+                    "regler": {
+                        "1": {
+                            "type": "lik",
+                            "sjekk": "3.8",
+                            "verdi": "Nei",
+                            "handling": {
+                                "type": "avslutt",
+                                "fasit": "Nei",
+                                "utfall": "Meningsbærende bilde har tekstalternativ som ikke er beskrivende."
+                            }
+                        },
+                        "2": {
+                            "type": "lik",
+                            "sjekk": "3.8",
+                            "verdi": "Ja",
+                            "handling": {
+                                "type": "avslutt",
+                                "fasit": "Ja",
+                                "utfall": "Meningsbærende bilde har beskrivende tekstalternativ."
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        {
+            "stegnr": "3.10",
+            "spm": "Gir det tilgjengelige navnet (kort tekstalternativ) en beskrivende identifikasjon av bildet?",
+            "ht": "<p>Gjør en skjønnsmessig vurdering av om det korte tekstalternativet identifiserer innholdet i bildet.</p>",
+            "type": "jaNei",
+            "ruting": {
+                "ja": {
+                    "type": "gaaTil",
+                    "steg": "3.11"
+                },
+                "nei": {
+                    "type": "avslutt",
+                    "fasit": "Nei",
+                    "utfall": "Komplekst bilde har kort tekstalternativ som ikke er beskrivende."
+                }
+            }
+        },
+        {
+            "stegnr": "3.11",
+            "spm": "Ligger det et langt tekstalternativ i direkte tilknytning til bildet, i leserekkefølgen?",
+            "ht": "<p><strong>Merk:</strong> For å være i direkte tilknytning, skal teksten ligge enten rett før, i, eller rett etter bildet i leserekkefølgen.</p><p><strong>Merk: </strong>Det lange tekstalternativet kan være tilgjengelig gjennom en mekanisme som knapp eller lenke.</p>",
+            "type": "jaNei",
+            "ruting": {
+                "ja": {
+                    "type": "gaaTil",
+                    "steg": "3.14"
+                },
+                "nei": {
+                    "type": "avslutt",
+                    "fasit": "Nei",
+                    "utfall": "Komplekst bilde på appsiden har ikke et langt tekstalternativ som beskriver innholdet i bildet."
+                }
+            }
+        },
+        {
+            "stegnr": "3.14",
+            "spm": "Gir det lange tekstalternativet en tilstrekkelig beskrivelse av innholdet i bildet?",
+            "ht": "<ul><li>sveip og trykk på det lange tekstalternativet, som det korte tekstalternativet refererer til</li><li><p>gjør en skjønnsmessig vurdering av om informasjonen i langt tekstalternativ gir tilstrekkelig informasjon om bildet til brukeren,</p></li></ul><p><strong>Tips:</strong> Et godt langt tekstalternativ gjør det mulig å erstatte bildet med tekstalternativet, uten å miste funksjonalitet eller informasjon. </p>",
+            "type": "jaNei",
+            "ruting": {
+                "ja": {
+                    "type": "avslutt",
+                    "fasit": "Ja",
+                    "utfall": "Komplekst bilde på appsiden har beskrivende, langt tekstalternativ."
+                },
+                "nei": {
+                    "type": "avslutt",
+                    "fasit": "Nei",
+                    "utfall": "Komplekst bilde på appsiden har et langt tekstalternativ, som ikke gir en tilstrekkelig beskrivelse av innholdet i bildet."
+                }
+            }
+        }
+    ]
+}


### PR DESCRIPTION
111aApp2025
3.11 Utfall endret til «Komplekst bilde på appsiden har ikke et langt tekstalternativ som beskriver innholdet i bildet». Det andre utfallet ga ikke mening. Dette utfallet svarer bedre på: Ligger det et langt tekstalternativ i direkte tilknytning til bildet, i leserekkefølgen?. Hvis det ikke er et langt tekstalternativ i direkte tilknytning er det heller ikke et langt tekstalternativ som beskriver innholdet i bildet.
3.13 Innarbeidet i 3.12
3.14 Plassering av langt tekstalternativ er ikke et krav i alt tekst.
Generelt: Merk: Navn er forenklet veldig, det er ikke lenger samsvar med spørsmål og svar men er praktisk enkelt. Dette blir vurdert videre etter statistisk gjennomgang og testing.
Generelt: Hjelpetekster er totalt endret. Det er ikke lenger «fakta» om testingen i tester, fremgangsmåter og viktig informasjon er bevart.
