### PR TITLE
Nett-1.4.3a Det er tilstrekkelig kontrast mellom tekst og bakgrunn 2025

### DIFF
--- a/Testreglar/1.4.3/Nett/143a2025.json
+++ b/Testreglar/1.4.3/Nett/143a2025.json
@@ -1,0 +1,140 @@
+{
+    "namn": "Nett-1.4.3a Det er tilstrekkelig kontrast mellom tekst og bakgrunn 2025",
+    "id": "143a2025",
+    "testlabId": 578,
+    "versjon": "1.0",
+    "type": "Nett",
+    "spraak": "nb",
+    "kravTilSamsvar": "<p>For nettsider med tekst gjelder følgende:</p><ul><li>Tekst har kontrast på minst 4,5:1 mot bakgrunnen.</li><li>Stor tekst har kontrast på minst 3,0:1 mot bakgrunnen.</li></ul>",
+    "side": "2.1",
+    "element": "3.1",
+    "steg": [
+        {
+            "stegnr": "2.1",
+            "spm": "Hvilken side tester du?",
+            "ht": "<p>Angi URL eller side-ID.</p>",
+            "type": "tekst",
+            "label": "URL/Side-ID:",
+            "datalist": "Sideutvalg",
+            "oblig": true,
+            "ruting": {
+                "alle": {
+                    "type": "gaaTil",
+                    "steg": "2.2"
+                }
+            }
+        },
+        {
+            "stegnr": "2.2",
+            "spm": "Har testsiden tekst som er omfattet av kravet?",
+            "ht": "<p><strong>Unntak:</strong></p><ul><li>tekst i logoer og varemerke</li><li>tekst som er ren dekorasjon</li><li>tekst i inaktive brukergrensesnittkomponenter, for eksempel deaktiverte knapper</li></ul><p><strong>Merk</strong>:</p><ul><li>Bilde av tekst skal testes i 1.4.3b</li><li>I skjema kan det hende at du må framprovosere eventuelle feilmeldinger og instruksjoner.</li></ul>",
+            "type": "jaNei",
+            "ruting": {
+                "ja": {
+                    "type": "gaaTil",
+                    "steg": "3.1"
+                },
+                "nei": {
+                    "type": "ikkjeForekomst",
+                    "utfall": "Testsiden har ikke tekst som er omfattet av kravet."
+                }
+            }
+        },
+        {
+            "stegnr": "3.1",
+            "spm": "Hvilken tekst tester du?",
+            "ht": "<p><strong>Bruk format:</strong></p><ul><li>Beskriv teksten</li><li>Beskriv plassering</li></ul><p><strong>Merk: </strong></p><ul><li>Hvis det er flere tekstelementer på siden, registrerer du ett og ett tekstelement.</li></ul>",
+            "type": "tekst",
+            "ruting": {
+                "alle": {
+                    "type": "gaaTil",
+                    "steg": "3.2"
+                }
+            },
+            "label": "Tekst:",
+            "multilinje": true
+        },
+        {
+            "stegnr": "3.2",
+            "spm": "Mål og registrer kontrast mellom tekst og bakgrunn.",
+            "ht": "<p><strong>Slik tester du:</strong></p><ul><li>Bruk Webaim Contrast Checker eller lignende for å vurdere kontrasten.</li><li>Registrer kontrast </li></ul><p><strong>Merk:</strong></p><ul><li>Dersom teksten er piksellert (får flere farger med zooming), skal du velge en farge som er representativ for hovedfargen på teksten.</li><li>Dersom bakgrunnen eller teksten er gradert, mønstret eller et bilde, skal du måle på det svakeste punktet.</li><li>Dersom bokstavene har et omriss på minst 1 piksel, vil omrisset være bakgrunnsfargen.</li></ul>",
+            "type": "tekst",
+            "ruting": {
+                "alle": {
+                    "type": "regler",
+                    "regler": {
+                        "1": {
+                            "sjekk": "3.2",
+                            "type": "mellom",
+                            "verdi": 0,
+                            "verdi2": 2.99,
+                            "handling": {
+                                "type": "avslutt",
+                                "fasit": "Nei",
+                                "utfall": "Tekst har kontrast mot bakgrunnen under 3,0:1."
+                            }
+                        },
+                        "2": {
+                            "sjekk": "3.2",
+                            "type": "mellom",
+                            "verdi": 3,
+                            "verdi2": 4.49,
+                            "handling": {
+                                "type": "gaaTil",
+                                "steg": "3.3"
+                            }
+                        },
+                        "3": {
+                            "sjekk": "3.2",
+                            "type": "mellom",
+                            "verdi": 4.5,
+                            "verdi2": 200,
+                            "handling": {
+                                "type": "avslutt",
+                                "fasit": "Ja",
+                                "utfall": "Tekst har kontrast mot bakgrunnen på minst 4,5:1."
+                            }
+                        }
+                    }
+                }
+            },
+            "label": "Målt kontrast (Format 4.48):",
+            "filter": "tal"
+        },
+        {
+            "stegnr": "3.3",
+            "spm": "Er skriftstørrelsen 24 px eller større?",
+            "ht": "<ul><li>Aktiver WhatFont.</li><li>Trykk på teksten du skal måle størrelsen på.</li><li>Registrer verdien som står i size</li></ul>",
+            "type": "jaNei",
+            "ruting": {
+                "ja": {
+                    "type": "avslutt",
+                    "fasit": "Ja",
+                    "utfall": "Stor tekst har kontrast mot bakgrunnen på minst 3,0:1."
+                },
+                "nei": {
+                    "type": "gaaTil",
+                    "steg": "3.4"
+                }
+            }
+        },
+        {
+            "stegnr": "3.4",
+            "spm": "Gjør en visuell inspeksjon av om teksten er fet?",
+            "ht": "",
+            "type": "jaNei",
+            "ruting": {
+                "ja": {
+                    "type": "avslutt",
+                    "fasit": "Ja",
+                    "utfall": "Stor tekst har kontrast mot bakgrunnen på minst 3,0:1."
+                },
+                "nei": {
+                    "type": "avslutt",
+                    "fasit": "Nei",
+                    "utfall": "Tekst har kontrast mot bakgrunnen på under 4,5:1."
+                }
+            }
+        }
+    ]
+}


### PR DESCRIPTION
143aNett2025
Steg 2.2
Dette er omfattet av kravet ((Hele er tatt vekk fordi testere vet hva som skal testes, det står i kravet.)
•	tekst
•	tekst i illustrasjoner og diagram (som ikke er bilde)
•	tekst i skjema inkl. placeholder
•	tekst som kommer til syne ved musepekeren over eller tastaturfokus

Merk: Dette skal ikke testes
•	bilde av tekst (blir testet i nett-1.4.3b) (Flyttet ned til merk)
•	Ikke-tekstlig innhold i diagram og grafer, som støttelinjer, søyler (blir testet i nett-1.4.11)( Er ikke tekst i det hele tatt)
•	tekst i logoer og varemerke(står enda)
•	tekst som er til pynt, dvs. tekst som kan erstattes av annen tekst, uten at meningsinnholdet blir endret (Er endret til ren dekorasjon)
•	tekst i bilde der teksten ikke er vesentlig for å formidle meningsinnholdet (er faktisk ren dekorasjon)
•	tekst i inaktive brukergrensesnittkomponenter, for eksempel deaktiverte knapper(ok)
•	tekst som ikke er synlig for brukeren (vi ser ikke denne uansett)
Utfall 2.2 er endret for å samsvare med spsm.
2.3 :
•	Fjernet alt, fungerer ikke som tiltenkt. Endret til: Bruk Webaim Contrast Checker eller lignende (på Mac/PC) for å vurdere kontrasten.
•	Registrer kontrast i TestLab (bruk desimaltall, for eksempel 4,5).
 
Merk:
•	Dersom teksten er piksellert (får flere farger med zooming), skal du velge en farge som er representativ for hovedfargen på teksten.
•	Dersom bakgrunnen eller teksten er gradert, mønstret eller et bilde, skal du måle på det svakeste punktet.
•	Dersom bokstavene har et omriss på minst 1 piksel, vil omrisset være bakgrunnsfargen.
