### PR TITLE
Nett-1.3.1a Visuelle overskrifter er korrekt kodet 2025

### DIFF
--- a/Testreglar/1.3.1/Nett/131a2025.json
+++ b/Testreglar/1.3.1/Nett/131a2025.json
@@ -159,16 +159,6 @@
 			"spm": "Samsvarer det visuelle hierarkiet med overskriftsnivået i koden?",
 			"ht": "<p>Visuelt hierarki:</p><ul><li>Sammenlign nivået på den visuelle overskriften med de forrige overskriftene.</li><li>Start på toppen av overskriftshierarkiet og tell deg nedover.</li><li>Husk at det kan være flere overskrifter på samme nivå etter hverandre</li></ul><p>Nivå i koden:</p><ul><li>Inspiser overskriften.</li><li>Sjekk om den er kodet med element <code>&lt;h1&gt;</code> til <code>&lt;h6&gt;</code>, eller <code>aria-level=\"1\"</code> til <code>aria-level=\"6\"</code>.</li></ul><p><strong>Merk:</strong> <code>&lt;h1&gt;</code> kan brukes mer enn en gang på samme side, dersom innhold på siden er delt inn i mer enn en blokk.</p>",
 			"type": "jaNei",
-			"svarArray": [
-				"Nivå 1",
-				"Nivå 2",
-				"Nivå 3",
-				"Nivå 4",
-				"Nivå 5",
-				"Nivå 6",
-				"Nivå 7",
-				"Nivå 8"
-			],
 			"ruting": {
 				"nei": {
 					"type": "avslutt",

--- a/Testreglar/1.3.1/Nett/131a2025.json
+++ b/Testreglar/1.3.1/Nett/131a2025.json
@@ -67,7 +67,7 @@
 			"ruting": {
 				"ja": {
 					"type": "gaaTil",
-					"steg": "3.5"
+					"steg": "3.4"
 				},
 				"nei": {
 					"type": "gaaTil",
@@ -87,38 +87,17 @@
 			"ruting": {
 				"ja": {
 					"type": "gaaTil",
-					"steg": "3.5"
+					"steg": "3.4"
 				},
 				"nei": {
 					"type": "avslutt",
 					"fasit": "Nei",
-					"utfall": "Visuell overskrift er ikke kodet som overskrift."
+					"utfall": "Visuell overskrift er ikke kodet som overskrift"
 				}
 			}
 		},
 		{
 			"stegnr": "3.4",
-			"spm": "Er den visuelle overskriften kodet på en annen måte, som ivaretar den visuelle presentasjonen?",
-			"ht": "<p>Eksempel på koding er:</p><ul><li>unummerert liste, kodet med <code>&lt;ul&gt;</code> og <code>&lt;li&gt;</code> for hvert listepunkt</li><li>nummerert liste, kodet med <code>&lt;ol&gt;</code> og <code>&lt;li&gt;</code> for hvert listepunkt</li><li>deskriptiv liste, kodet med <code>&lt;dl&gt;</code>, <code>&lt;dd&gt;</code> og <code>&lt;dt&gt;</code></li><li>Ledetekst kodet som <code>&lt;label&gt;</code></li></ul>",
-			"type": "jaNei",
-			"kilde": [
-				"F2",
-				"G115"
-			],
-			"ruting": {
-				"ja": {
-					"type": "ikkjeForekomst",
-					"utfall": "Visuell overskrift er kodet på en annen gyldig måte som ivaretar den visuelle presentasjonen."
-				},
-				"nei": {
-					"type": "avslutt",
-					"fasit": "Nei",
-					"utfall": "Visuell overskrift er ikke kodet som overskrift."
-				}
-			}
-		},
-		{
-			"stegnr": "3.5",
 			"spm": "Er overskriften kodet slik at den ignoreres av hjelpemiddelteknologi?",
 			"ht": "<ul><li>Inspiser overskriften.</li><li>Bruk Accessibility Tree, og sjekk under Computed Properties, om det står:<br><ul><li>\"Accessibility node not exposed».</li></ul></li></ul><p>Eller</p><ul><li>Sjekk om overskriften er kodet med en av følgende attributter:<ul><li><code>role=«presentation»</code>.</li><li><code>role=«none»</code>.</li><li><code>aria-hidden=«true»</code>.</li></ul></li></ul>",
 			"type": "jaNei",
@@ -130,7 +109,7 @@
 				},
 				"nei": {
 					"type": "gaaTil",
-					"steg": "3.6"
+					"steg": "3.5"
 				}
 			},
 			"kilde": [
@@ -138,14 +117,14 @@
 			]
 		},
 		{
-			"stegnr": "3.6",
+			"stegnr": "3.5",
 			"spm": "Inngår den visuelle overskriften i et tydelig overskriftshierarki?",
 			"ht": "<p><strong>Merk:</strong> Du skal ikke vurdere hierarkiet på overskriftene for hele nettsiden samlet, bare de delene av nettsidene som er delt opp med et visuelt overskriftshierarki.</p>",
 			"type": "jaNei",
 			"ruting": {
 				"ja": {
 					"type": "gaaTil",
-					"steg": "3.7"
+					"steg": "3.6"
 				},
 				"nei": {
 					"type": "avslutt",
@@ -155,7 +134,7 @@
 			}
 		},
 		{
-			"stegnr": "3.7",
+			"stegnr": "3.6",
 			"spm": "Samsvarer det visuelle hierarkiet med overskriftsnivået i koden?",
 			"ht": "<p>Visuelt hierarki:</p><ul><li>Sammenlign nivået på den visuelle overskriften med de forrige overskriftene.</li><li>Start på toppen av overskriftshierarkiet og tell deg nedover.</li><li>Husk at det kan være flere overskrifter på samme nivå etter hverandre</li></ul><p>Nivå i koden:</p><ul><li>Inspiser overskriften.</li><li>Sjekk om den er kodet med element <code>&lt;h1&gt;</code> til <code>&lt;h6&gt;</code>, eller <code>aria-level=\"1\"</code> til <code>aria-level=\"6\"</code>.</li></ul><p><strong>Merk:</strong> <code>&lt;h1&gt;</code> kan brukes mer enn en gang på samme side, dersom innhold på siden er delt inn i mer enn en blokk.</p>",
 			"type": "jaNei",

--- a/Testreglar/1.3.1/Nett/131a2025.json
+++ b/Testreglar/1.3.1/Nett/131a2025.json
@@ -43,7 +43,7 @@
 		{
 			"stegnr": "3.1",
 			"spm": "Hvilken overskrift tester du?",
-			"ht": "<p><strong>Bruk format:</strong></p><ul><li>Beskriv overskriften.</li><li>Beskriv plassering.</li></ul><p><strong>Merk:</strong> Hvis det er flere overskrifter på siden, registrerer du en og en.</p>",
+			"ht": "<ul><li>Beskriv overskriften.</li><li>Beskriv plassering.</li></ul><p><strong>Merk:</strong> Hvis det er flere overskrifter på siden, registrerer du en og en.</p>",
 			"type": "tekst",
 			"label": "Overskrift:",
 			"multilinje": true,

--- a/Testreglar/1.3.1/Nett/131a2025.json
+++ b/Testreglar/1.3.1/Nett/131a2025.json
@@ -1,186 +1,186 @@
 {
-    "namn": "Nett-1.3.1a Visuelle overskrifter er korrekt kodet 2025",
-    "id": "131a2025",
-    "testlabId": 560,
-    "versjon": "1.0",
-    "type": "Nett",
-    "spraak": "nb",
-    "kravTilSamsvar": "<ul><li>Visuelle overskrifter er korrekt kodet som overskrifter</li><li>Visuelle overskrifter som inngår i et overskriftshierarki, er kodet med rett overskriftsnivå</li></ul>",
-    "side": "2.1",
-    "element": "3.1",
-    "steg": [
-        {
-            "stegnr": "2.1",
-            "spm": "Hvilken side tester du?",
-            "ht": "<p>Angi URL eller side-ID.</p>",
-            "type": "tekst",
-            "label": "URL/Side:",
-            "datalist": "Sideutvalg",
-            "oblig": true,
-            "ruting": {
-                "alle": {
-                    "type": "gaaTil",
-                    "steg": "2.2"
-                }
-            }
-        },
-        {
-            "stegnr": "2.2",
-            "spm": "Har nettsiden visuelle overskrifter?",
-            "ht": "<ul><li>Gjør en visuell inspeksjon.</li></ul>",
-            "type": "jaNei",
-            "ruting": {
-                "ja": {
-                    "type": "gaaTil",
-                    "steg": "3.1"
-                },
-                "nei": {
-                    "type": "ikkjeForekomst",
-                    "utfall": "Testsiden har ikke visuelle overskrifter."
-                }
-            }
-        },
-        {
-            "stegnr": "3.1",
-            "spm": "Hvilken overskrift tester du?",
-            "ht": "<p><strong>Bruk format:</strong></p><ul><li>Beskriv overskriften.</li><li>Beskriv plassering.</li></ul><p><strong>Merk:</strong> Hvis det er flere overskrifter på siden, registrerer du en og en.</p><p> </p>",
-            "type": "tekst",
-            "label": "Overskrift:",
-            "multilinje": true,
-            "oblig": true,
-            "ruting": {
-                "alle": {
-                    "type": "gaaTil",
-                    "steg": "3.2"
-                }
-            }
-        },
-        {
-            "stegnr": "3.2",
-            "spm": "Er den visuelle overskriften kodet som overskrift med &lt;h1&gt; til &lt;h6&gt;?",
-            "ht": "<ul><li>Inspiser overskriften.</li></ul>",
-            "type": "jaNei",
-            "kilde": [
-                "F2",
-                "H42"
-            ],
-            "ruting": {
-                "ja": {
-                    "type": "gaaTil",
-                    "steg": "3.5"
-                },
-                "nei": {
-                    "type": "gaaTil",
-                    "steg": "3.3"
-                }
-            }
-        },
-        {
-            "stegnr": "3.3",
-            "spm": "Er den visuelle overskriften kodet med attributtet role=\"heading\"?",
-            "ht": "<ul><li>Inspiser overskriften,</li><li>eller bruk Accessibility Tree verktøyet under Computed Properties og sjekk om det står <code>role=\"heading\"</code>.</li></ul>",
-            "type": "jaNei",
-            "kilde": [
-                "ARIA12",
-                "F2"
-            ],
-            "ruting": {
-                "ja": {
-                    "type": "gaaTil",
-                    "steg": "3.5"
-                },
-                "nei": {
-                    "type": "avslutt",
-                    "fasit": "Nei",
-                    "utfall": "Visuell overskrift er ikke kodet som overskrift."
-                }
-            }
-        },
-        {
-            "stegnr": "3.4",
-            "spm": "Er den visuelle overskriften kodet på en annen måte, som ivaretar den visuelle presentasjonen?",
-            "ht": "<p>Eksempel på koding er:</p><ul><li>unummerert liste, kodet med <code>&lt;ul&gt;</code> og <code>&lt;li&gt;</code> for hvert listepunkt</li><li>nummerert liste, kodet med <code>&lt;ol&gt;</code> og <code>&lt;li&gt;</code> for hvert listepunkt</li><li>deskriptiv liste, kodet med <code>&lt;dl&gt;</code>, <code>&lt;dd&gt;</code> og <code>&lt;dt&gt;</code></li><li>Ledetekst kodet som <code>&lt;label&gt;</code></li></ul>",
-            "type": "jaNei",
-            "kilde": [
-                "F2",
-                "G115"
-            ],
-            "ruting": {
-                "ja": {
-                    "type": "ikkjeForekomst",
-                    "utfall": "Visuell overskrift er kodet på en annen gyldig måte som ivaretar den visuelle presentasjonen."
-                },
-                "nei": {
-                    "type": "avslutt",
-                    "fasit": "Nei",
-                    "utfall": "Visuell overskrift er ikke kodet som overskrift."
-                }
-            }
-        },
-        {
-            "stegnr": "3.5",
-            "spm": "Er overskriften kodet slik at den ignoreres av hjelpemiddelteknologi?",
-            "ht": "<ul><li>Inspiser overskriften.</li><li>Bruk Accessibility Tree, og sjekk under Computed Properties, om det står:<br><ul><li>\"Accessibility node not exposed».</li></ul></li></ul><p>Eller</p><ul><li>Sjekk om overskriften er kodet med en av følgende attributter:<ul><li><code>role=«presentation»</code>.</li><li><code>role=«none»</code>.</li><li><code>aria-hidden=«true»</code>.</li></ul></li></ul>",
-            "type": "jaNei",
-            "ruting": {
-                "ja": {
-                    "type": "avslutt",
-                    "fasit": "Nei",
-                    "utfall": "Overskrift er kodet slik at den ignoreres av hjelpemiddelteknologi."
-                },
-                "nei": {
-                    "type": "gaaTil",
-                    "steg": "3.6"
-                }
-            },
-            "kilde": [
-                "F92"
-            ]
-        },
-        {
-            "stegnr": "3.6",
-            "spm": "Inngår den visuelle overskriften i et tydelig overskriftshierarki?",
-            "ht": "<p><strong>Merk:</strong> Du skal ikke vurdere hierarkiet på overskriftene for hele nettsiden samlet, bare de delene av nettsidene som er delt opp med et visuelt overskriftshierarki.</p>",
-            "type": "jaNei",
-            "ruting": {
-                "ja": {
-                    "type": "gaaTil",
-                    "steg": "3.7"
-                },
-                "nei": {
-                    "type": "avslutt",
-                    "fasit": "Ja",
-                    "utfall": "Visuell overskrift er kodet som overskrift."
-                }
-            }
-        },
-        {
-            "stegnr": "3.7",
-            "spm": "Samsvarer det visuelle hierarkiet med overskriftsnivået i koden?",
-            "ht": "<p>Visuelt hierarki:</p><ul><li>Sammenlign nivået på den visuelle overskriften med de forrige overskriftene.</li><li>Start på toppen av overskriftshierarkiet og tell deg nedover.</li><li>Husk at det kan være flere overskrifter på samme nivå etter hverandre</li></ul><p>Nivå i koden:</p><ul><li>Inspiser overskriften.</li><li>Sjekk om den er kodet med element <code>&lt;h1&gt;</code> til <code>&lt;h6&gt;</code>, eller <code>aria-level=\"1\"</code> til <code>aria-level=\"6\"</code>.</li></ul><p><strong>Merk:</strong> <code>&lt;h1&gt;</code> kan brukes mer enn en gang på samme side, dersom innhold på siden er delt inn i mer enn en blokk.</p>",
-            "type": "jaNei",
-            "svarArray": [
-                "Nivå 1",
-                "Nivå 2",
-                "Nivå 3",
-                "Nivå 4",
-                "Nivå 5",
-                "Nivå 6",
-                "Nivå 7",
-                "Nivå 8"
-            ],
-            "ruting": {
-                "nei": {
-                    "type": "avslutt",
-                    "fasit": "Nei",
-                    "utfall": "Visuell overskrift er kodet som overskrift. Visuelt overskriftsnivå samsvarer ikke med kodet overskriftsnivå."
-                },
-                "ja": {
-                    "type": "avslutt",
-                    "fasit": "Ja",
-                    "utfall": "Visuell overskrift er kodet som overskrift. Visuelt overskriftsnivå samsvarer med kodet overskriftsnivå."
-                }
-            }
-        }
-    ]
+	"namn": "Nett-1.3.1a Visuelle overskrifter er korrekt kodet 2025",
+	"id": "131a2025",
+	"testlabId": 560,
+	"versjon": "1.0",
+	"type": "Nett",
+	"spraak": "nb",
+	"kravTilSamsvar": "<ul><li>Visuelle overskrifter er korrekt kodet som overskrifter</li><li>Visuelle overskrifter som inngår i et overskriftshierarki, er kodet med rett overskriftsnivå</li></ul>",
+	"side": "2.1",
+	"element": "3.1",
+	"steg": [
+		{
+			"stegnr": "2.1",
+			"spm": "Hvilken side tester du?",
+			"ht": "<p>Angi URL eller side-ID.</p>",
+			"type": "tekst",
+			"label": "URL/Side:",
+			"datalist": "Sideutvalg",
+			"oblig": true,
+			"ruting": {
+				"alle": {
+					"type": "gaaTil",
+					"steg": "2.2"
+				}
+			}
+		},
+		{
+			"stegnr": "2.2",
+			"spm": "Har nettsiden visuelle overskrifter?",
+			"ht": "<ul><li>Gjør en visuell inspeksjon.</li></ul>",
+			"type": "jaNei",
+			"ruting": {
+				"ja": {
+					"type": "gaaTil",
+					"steg": "3.1"
+				},
+				"nei": {
+					"type": "ikkjeForekomst",
+					"utfall": "Testsiden har ikke visuelle overskrifter."
+				}
+			}
+		},
+		{
+			"stegnr": "3.1",
+			"spm": "Hvilken overskrift tester du?",
+			"ht": "<p><strong>Bruk format:</strong></p><ul><li>Beskriv overskriften.</li><li>Beskriv plassering.</li></ul><p><strong>Merk:</strong> Hvis det er flere overskrifter på siden, registrerer du en og en.</p>",
+			"type": "tekst",
+			"label": "Overskrift:",
+			"multilinje": true,
+			"oblig": true,
+			"ruting": {
+				"alle": {
+					"type": "gaaTil",
+					"steg": "3.2"
+				}
+			}
+		},
+		{
+			"stegnr": "3.2",
+			"spm": "Er den visuelle overskriften kodet som overskrift med &lt;h1&gt; til &lt;h6&gt;?",
+			"ht": "<ul><li>Inspiser overskriften.</li></ul>",
+			"type": "jaNei",
+			"kilde": [
+				"F2",
+				"H42"
+			],
+			"ruting": {
+				"ja": {
+					"type": "gaaTil",
+					"steg": "3.5"
+				},
+				"nei": {
+					"type": "gaaTil",
+					"steg": "3.3"
+				}
+			}
+		},
+		{
+			"stegnr": "3.3",
+			"spm": "Er den visuelle overskriften kodet med attributtet role=\"heading\"?",
+			"ht": "<ul><li>Inspiser overskriften,</li><li>eller bruk Accessibility Tree verktøyet under Computed Properties og sjekk om det står <code>role=\"heading\"</code>.</li></ul>",
+			"type": "jaNei",
+			"kilde": [
+				"ARIA12",
+				"F2"
+			],
+			"ruting": {
+				"ja": {
+					"type": "gaaTil",
+					"steg": "3.5"
+				},
+				"nei": {
+					"type": "avslutt",
+					"fasit": "Nei",
+					"utfall": "Visuell overskrift er ikke kodet som overskrift."
+				}
+			}
+		},
+		{
+			"stegnr": "3.4",
+			"spm": "Er den visuelle overskriften kodet på en annen måte, som ivaretar den visuelle presentasjonen?",
+			"ht": "<p>Eksempel på koding er:</p><ul><li>unummerert liste, kodet med <code>&lt;ul&gt;</code> og <code>&lt;li&gt;</code> for hvert listepunkt</li><li>nummerert liste, kodet med <code>&lt;ol&gt;</code> og <code>&lt;li&gt;</code> for hvert listepunkt</li><li>deskriptiv liste, kodet med <code>&lt;dl&gt;</code>, <code>&lt;dd&gt;</code> og <code>&lt;dt&gt;</code></li><li>Ledetekst kodet som <code>&lt;label&gt;</code></li></ul>",
+			"type": "jaNei",
+			"kilde": [
+				"F2",
+				"G115"
+			],
+			"ruting": {
+				"ja": {
+					"type": "ikkjeForekomst",
+					"utfall": "Visuell overskrift er kodet på en annen gyldig måte som ivaretar den visuelle presentasjonen."
+				},
+				"nei": {
+					"type": "avslutt",
+					"fasit": "Nei",
+					"utfall": "Visuell overskrift er ikke kodet som overskrift."
+				}
+			}
+		},
+		{
+			"stegnr": "3.5",
+			"spm": "Er overskriften kodet slik at den ignoreres av hjelpemiddelteknologi?",
+			"ht": "<ul><li>Inspiser overskriften.</li><li>Bruk Accessibility Tree, og sjekk under Computed Properties, om det står:<br><ul><li>\"Accessibility node not exposed».</li></ul></li></ul><p>Eller</p><ul><li>Sjekk om overskriften er kodet med en av følgende attributter:<ul><li><code>role=«presentation»</code>.</li><li><code>role=«none»</code>.</li><li><code>aria-hidden=«true»</code>.</li></ul></li></ul>",
+			"type": "jaNei",
+			"ruting": {
+				"ja": {
+					"type": "avslutt",
+					"fasit": "Nei",
+					"utfall": "Overskrift er kodet slik at den ignoreres av hjelpemiddelteknologi."
+				},
+				"nei": {
+					"type": "gaaTil",
+					"steg": "3.6"
+				}
+			},
+			"kilde": [
+				"F92"
+			]
+		},
+		{
+			"stegnr": "3.6",
+			"spm": "Inngår den visuelle overskriften i et tydelig overskriftshierarki?",
+			"ht": "<p><strong>Merk:</strong> Du skal ikke vurdere hierarkiet på overskriftene for hele nettsiden samlet, bare de delene av nettsidene som er delt opp med et visuelt overskriftshierarki.</p>",
+			"type": "jaNei",
+			"ruting": {
+				"ja": {
+					"type": "gaaTil",
+					"steg": "3.7"
+				},
+				"nei": {
+					"type": "avslutt",
+					"fasit": "Ja",
+					"utfall": "Visuell overskrift er kodet som overskrift."
+				}
+			}
+		},
+		{
+			"stegnr": "3.7",
+			"spm": "Samsvarer det visuelle hierarkiet med overskriftsnivået i koden?",
+			"ht": "<p>Visuelt hierarki:</p><ul><li>Sammenlign nivået på den visuelle overskriften med de forrige overskriftene.</li><li>Start på toppen av overskriftshierarkiet og tell deg nedover.</li><li>Husk at det kan være flere overskrifter på samme nivå etter hverandre</li></ul><p>Nivå i koden:</p><ul><li>Inspiser overskriften.</li><li>Sjekk om den er kodet med element <code>&lt;h1&gt;</code> til <code>&lt;h6&gt;</code>, eller <code>aria-level=\"1\"</code> til <code>aria-level=\"6\"</code>.</li></ul><p><strong>Merk:</strong> <code>&lt;h1&gt;</code> kan brukes mer enn en gang på samme side, dersom innhold på siden er delt inn i mer enn en blokk.</p>",
+			"type": "jaNei",
+			"svarArray": [
+				"Nivå 1",
+				"Nivå 2",
+				"Nivå 3",
+				"Nivå 4",
+				"Nivå 5",
+				"Nivå 6",
+				"Nivå 7",
+				"Nivå 8"
+			],
+			"ruting": {
+				"nei": {
+					"type": "avslutt",
+					"fasit": "Nei",
+					"utfall": "Visuell overskrift er kodet som overskrift. Visuelt overskriftsnivå samsvarer ikke med kodet overskriftsnivå."
+				},
+				"ja": {
+					"type": "avslutt",
+					"fasit": "Ja",
+					"utfall": "Visuell overskrift er kodet som overskrift. Visuelt overskriftsnivå samsvarer med kodet overskriftsnivå."
+				}
+			}
+		}
+	]
 }

--- a/Testreglar/1.3.1/Nett/131a2025.json
+++ b/Testreglar/1.3.1/Nett/131a2025.json
@@ -1,0 +1,186 @@
+{
+    "namn": "Nett-1.3.1a Visuelle overskrifter er korrekt kodet 2025",
+    "id": "131a2025",
+    "testlabId": 560,
+    "versjon": "1.0",
+    "type": "Nett",
+    "spraak": "nb",
+    "kravTilSamsvar": "<ul><li>Visuelle overskrifter er korrekt kodet som overskrifter</li><li>Visuelle overskrifter som inngår i et overskriftshierarki, er kodet med rett overskriftsnivå</li></ul>",
+    "side": "2.1",
+    "element": "3.1",
+    "steg": [
+        {
+            "stegnr": "2.1",
+            "spm": "Hvilken side tester du?",
+            "ht": "<p>Angi URL eller side-ID.</p>",
+            "type": "tekst",
+            "label": "URL/Side:",
+            "datalist": "Sideutvalg",
+            "oblig": true,
+            "ruting": {
+                "alle": {
+                    "type": "gaaTil",
+                    "steg": "2.2"
+                }
+            }
+        },
+        {
+            "stegnr": "2.2",
+            "spm": "Har nettsiden visuelle overskrifter?",
+            "ht": "<ul><li>Gjør en visuell inspeksjon.</li></ul>",
+            "type": "jaNei",
+            "ruting": {
+                "ja": {
+                    "type": "gaaTil",
+                    "steg": "3.1"
+                },
+                "nei": {
+                    "type": "ikkjeForekomst",
+                    "utfall": "Testsiden har ikke visuelle overskrifter."
+                }
+            }
+        },
+        {
+            "stegnr": "3.1",
+            "spm": "Hvilken overskrift tester du?",
+            "ht": "<p><strong>Bruk format:</strong></p><ul><li>Beskriv overskriften.</li><li>Beskriv plassering.</li></ul><p><strong>Merk:</strong> Hvis det er flere overskrifter på siden, registrerer du en og en.</p><p> </p>",
+            "type": "tekst",
+            "label": "Overskrift:",
+            "multilinje": true,
+            "oblig": true,
+            "ruting": {
+                "alle": {
+                    "type": "gaaTil",
+                    "steg": "3.2"
+                }
+            }
+        },
+        {
+            "stegnr": "3.2",
+            "spm": "Er den visuelle overskriften kodet som overskrift med &lt;h1&gt; til &lt;h6&gt;?",
+            "ht": "<ul><li>Inspiser overskriften.</li></ul>",
+            "type": "jaNei",
+            "kilde": [
+                "F2",
+                "H42"
+            ],
+            "ruting": {
+                "ja": {
+                    "type": "gaaTil",
+                    "steg": "3.5"
+                },
+                "nei": {
+                    "type": "gaaTil",
+                    "steg": "3.3"
+                }
+            }
+        },
+        {
+            "stegnr": "3.3",
+            "spm": "Er den visuelle overskriften kodet med attributtet role=\"heading\"?",
+            "ht": "<ul><li>Inspiser overskriften,</li><li>eller bruk Accessibility Tree verktøyet under Computed Properties og sjekk om det står <code>role=\"heading\"</code>.</li></ul>",
+            "type": "jaNei",
+            "kilde": [
+                "ARIA12",
+                "F2"
+            ],
+            "ruting": {
+                "ja": {
+                    "type": "gaaTil",
+                    "steg": "3.5"
+                },
+                "nei": {
+                    "type": "avslutt",
+                    "fasit": "Nei",
+                    "utfall": "Visuell overskrift er ikke kodet som overskrift."
+                }
+            }
+        },
+        {
+            "stegnr": "3.4",
+            "spm": "Er den visuelle overskriften kodet på en annen måte, som ivaretar den visuelle presentasjonen?",
+            "ht": "<p>Eksempel på koding er:</p><ul><li>unummerert liste, kodet med <code>&lt;ul&gt;</code> og <code>&lt;li&gt;</code> for hvert listepunkt</li><li>nummerert liste, kodet med <code>&lt;ol&gt;</code> og <code>&lt;li&gt;</code> for hvert listepunkt</li><li>deskriptiv liste, kodet med <code>&lt;dl&gt;</code>, <code>&lt;dd&gt;</code> og <code>&lt;dt&gt;</code></li><li>Ledetekst kodet som <code>&lt;label&gt;</code></li></ul>",
+            "type": "jaNei",
+            "kilde": [
+                "F2",
+                "G115"
+            ],
+            "ruting": {
+                "ja": {
+                    "type": "ikkjeForekomst",
+                    "utfall": "Visuell overskrift er kodet på en annen gyldig måte som ivaretar den visuelle presentasjonen."
+                },
+                "nei": {
+                    "type": "avslutt",
+                    "fasit": "Nei",
+                    "utfall": "Visuell overskrift er ikke kodet som overskrift."
+                }
+            }
+        },
+        {
+            "stegnr": "3.5",
+            "spm": "Er overskriften kodet slik at den ignoreres av hjelpemiddelteknologi?",
+            "ht": "<ul><li>Inspiser overskriften.</li><li>Bruk Accessibility Tree, og sjekk under Computed Properties, om det står:<br><ul><li>\"Accessibility node not exposed».</li></ul></li></ul><p>Eller</p><ul><li>Sjekk om overskriften er kodet med en av følgende attributter:<ul><li><code>role=«presentation»</code>.</li><li><code>role=«none»</code>.</li><li><code>aria-hidden=«true»</code>.</li></ul></li></ul>",
+            "type": "jaNei",
+            "ruting": {
+                "ja": {
+                    "type": "avslutt",
+                    "fasit": "Nei",
+                    "utfall": "Overskrift er kodet slik at den ignoreres av hjelpemiddelteknologi."
+                },
+                "nei": {
+                    "type": "gaaTil",
+                    "steg": "3.6"
+                }
+            },
+            "kilde": [
+                "F92"
+            ]
+        },
+        {
+            "stegnr": "3.6",
+            "spm": "Inngår den visuelle overskriften i et tydelig overskriftshierarki?",
+            "ht": "<p><strong>Merk:</strong> Du skal ikke vurdere hierarkiet på overskriftene for hele nettsiden samlet, bare de delene av nettsidene som er delt opp med et visuelt overskriftshierarki.</p>",
+            "type": "jaNei",
+            "ruting": {
+                "ja": {
+                    "type": "gaaTil",
+                    "steg": "3.7"
+                },
+                "nei": {
+                    "type": "avslutt",
+                    "fasit": "Ja",
+                    "utfall": "Visuell overskrift er kodet som overskrift."
+                }
+            }
+        },
+        {
+            "stegnr": "3.7",
+            "spm": "Samsvarer det visuelle hierarkiet med overskriftsnivået i koden?",
+            "ht": "<p>Visuelt hierarki:</p><ul><li>Sammenlign nivået på den visuelle overskriften med de forrige overskriftene.</li><li>Start på toppen av overskriftshierarkiet og tell deg nedover.</li><li>Husk at det kan være flere overskrifter på samme nivå etter hverandre</li></ul><p>Nivå i koden:</p><ul><li>Inspiser overskriften.</li><li>Sjekk om den er kodet med element <code>&lt;h1&gt;</code> til <code>&lt;h6&gt;</code>, eller <code>aria-level=\"1\"</code> til <code>aria-level=\"6\"</code>.</li></ul><p><strong>Merk:</strong> <code>&lt;h1&gt;</code> kan brukes mer enn en gang på samme side, dersom innhold på siden er delt inn i mer enn en blokk.</p>",
+            "type": "jaNei",
+            "svarArray": [
+                "Nivå 1",
+                "Nivå 2",
+                "Nivå 3",
+                "Nivå 4",
+                "Nivå 5",
+                "Nivå 6",
+                "Nivå 7",
+                "Nivå 8"
+            ],
+            "ruting": {
+                "nei": {
+                    "type": "avslutt",
+                    "fasit": "Nei",
+                    "utfall": "Visuell overskrift er kodet som overskrift. Visuelt overskriftsnivå samsvarer ikke med kodet overskriftsnivå."
+                },
+                "ja": {
+                    "type": "avslutt",
+                    "fasit": "Ja",
+                    "utfall": "Visuell overskrift er kodet som overskrift. Visuelt overskriftsnivå samsvarer med kodet overskriftsnivå."
+                }
+            }
+        }
+    ]
+}

--- a/index.json
+++ b/index.json
@@ -9,8 +9,32 @@
       "file": "/Testreglar/1.1.1/App/app-1.1.1f.json"
     },
     {
-      "id": "app-1.2.2a",
-      "file": "/Testreglar/1.2.2/App/app-1.2.2a.json"
+      "id": "app-1.2.1a",
+      "file": "/Testreglar/1.2.1/App/app-1.2.1a.json"
+    },
+    {
+      "id": "app-1.2.1b",
+      "file": "/Testreglar/1.2.1/App/app-1.2.1b.json"
+    },
+    {
+      "id": "1.2.1a",
+      "file": "/Testreglar/1.2.1/Nett/1.2.1a.json"
+    },
+    {
+      "id": "1.2.1b",
+      "file": "/Testreglar/1.2.1/Nett/1.2.1b.json"
+    },
+    {
+      "id": "nett-1.2.1a",
+      "file": "/Testreglar/1.2.1/Nett/nett-1.2.1a.json"
+    },
+    {
+      "id": "nett-1.2.1b",
+      "file": "/Testreglar/1.2.1/Nett/nett-1.2.1b.json"
+    },
+    {
+      "id": "app-1.2.5a",
+      "file": "/Testreglar/1.2.5/App/app-1.2.5a.json"
     },
     {
       "id": "1.1.1a",
@@ -49,6 +73,10 @@
       "file": "/Testreglar/1.1.1/Nett/nett-1.1.1f.json"
     },
     {
+      "id": "app-1.2.2a",
+      "file": "/Testreglar/1.2.2/App/app-1.2.2a.json"
+    },
+    {
       "id": "nett-1.2.5a",
       "file": "/Testreglar/1.2.5/Nett/nett-1.2.5a.json"
     },
@@ -61,28 +89,24 @@
       "file": "/Testreglar/1.2.2/Nett/nett-1.2.2a.json"
     },
     {
-      "id": "1.2.1a",
-      "file": "/Testreglar/1.2.1/Nett/1.2.1a.json"
+      "id": "1.3.2a",
+      "file": "/Testreglar/1.3.2/Nett/1.3.2a.json"
     },
     {
-      "id": "1.2.1b",
-      "file": "/Testreglar/1.2.1/Nett/1.2.1b.json"
+      "id": "nett-1.3.2a",
+      "file": "/Testreglar/1.3.2/Nett/nett-1.3.2a.json"
     },
     {
-      "id": "nett-1.2.1a",
-      "file": "/Testreglar/1.2.1/Nett/nett-1.2.1a.json"
+      "id": "app-1.3.4a",
+      "file": "/Testreglar/1.3.4/App/app-1.3.4a.json"
     },
     {
-      "id": "nett-1.2.1b",
-      "file": "/Testreglar/1.2.1/Nett/nett-1.2.1b.json"
+      "id": "app-1.3.2a",
+      "file": "/Testreglar/1.3.2/App/app-1.3.2a.json"
     },
     {
-      "id": "app-1.2.1a",
-      "file": "/Testreglar/1.2.1/App/app-1.2.1a.json"
-    },
-    {
-      "id": "app-1.2.1b",
-      "file": "/Testreglar/1.2.1/App/app-1.2.1b.json"
+      "id": "app-1.3.3a",
+      "file": "/Testreglar/1.3.3/App/app-1.3.3a.json"
     },
     {
       "id": "1.3.3a",
@@ -91,14 +115,6 @@
     {
       "id": "nett-1.3.3a",
       "file": "/Testreglar/1.3.3/Nett/nett-1.3.3a.json"
-    },
-    {
-      "id": "app-1.2.5a",
-      "file": "/Testreglar/1.2.5/App/app-1.2.5a.json"
-    },
-    {
-      "id": "app-1.3.3a",
-      "file": "/Testreglar/1.3.3/App/app-1.3.3a.json"
     },
     {
       "id": "app-1.3.5a",
@@ -113,8 +129,16 @@
       "file": "/Testreglar/1.3.1/App/app-1.3.1c.json"
     },
     {
-      "id": "app-1.3.4a",
-      "file": "/Testreglar/1.3.4/App/app-1.3.4a.json"
+      "id": "nett-1.4.1a",
+      "file": "/Testreglar/1.4.1/Nett/nett-1.4.1a.json"
+    },
+    {
+      "id": "nett-1.4.1b",
+      "file": "/Testreglar/1.4.1/Nett/nett-1.4.1b.json"
+    },
+    {
+      "id": "nett-1.4.1c",
+      "file": "/Testreglar/1.4.1/Nett/nett-1.4.1c.json"
     },
     {
       "id": "1.3.1a",
@@ -127,6 +151,10 @@
     {
       "id": "1.3.1c",
       "file": "/Testreglar/1.3.1/Nett/1.3.1c.json"
+    },
+    {
+      "id": "131a2025",
+      "file": "/Testreglar/1.3.1/Nett/131a2025.json"
     },
     {
       "id": "nett-1.3.1a",
@@ -153,22 +181,6 @@
       "file": "/Testreglar/1.3.1/Nett/nett-1.3.1f.json"
     },
     {
-      "id": "app-1.4.10a",
-      "file": "/Testreglar/1.4.10/App/app-1.4.10a.json"
-    },
-    {
-      "id": "app-1.3.2a",
-      "file": "/Testreglar/1.3.2/App/app-1.3.2a.json"
-    },
-    {
-      "id": "1.3.2a",
-      "file": "/Testreglar/1.3.2/Nett/1.3.2a.json"
-    },
-    {
-      "id": "nett-1.3.2a",
-      "file": "/Testreglar/1.3.2/Nett/nett-1.3.2a.json"
-    },
-    {
       "id": "app-1.4.1a",
       "file": "/Testreglar/1.4.1/App/app-1.4.1a.json"
     },
@@ -185,28 +197,12 @@
       "file": "/Testreglar/1.4.10/Nett/nett-1.4.10a.json"
     },
     {
-      "id": "nett-1.4.11a",
-      "file": "/Testreglar/1.4.11/Nett/nett-1.4.11a.json"
+      "id": "nett-1.4.12a",
+      "file": "/Testreglar/1.4.12/Nett/nett-1.4.12a.json"
     },
     {
-      "id": "nett-1.4.11b",
-      "file": "/Testreglar/1.4.11/Nett/nett-1.4.11b.json"
-    },
-    {
-      "id": "nett-1.4.11c",
-      "file": "/Testreglar/1.4.11/Nett/nett-1.4.11c.json"
-    },
-    {
-      "id": "nett-1.4.1a",
-      "file": "/Testreglar/1.4.1/Nett/nett-1.4.1a.json"
-    },
-    {
-      "id": "nett-1.4.1b",
-      "file": "/Testreglar/1.4.1/Nett/nett-1.4.1b.json"
-    },
-    {
-      "id": "nett-1.4.1c",
-      "file": "/Testreglar/1.4.1/Nett/nett-1.4.1c.json"
+      "id": "app-1.4.10a",
+      "file": "/Testreglar/1.4.10/App/app-1.4.10a.json"
     },
     {
       "id": "app-1.4.11a",
@@ -221,6 +217,18 @@
       "file": "/Testreglar/1.4.11/App/app-1.4.11c.json"
     },
     {
+      "id": "nett-1.4.11a",
+      "file": "/Testreglar/1.4.11/Nett/nett-1.4.11a.json"
+    },
+    {
+      "id": "nett-1.4.11b",
+      "file": "/Testreglar/1.4.11/Nett/nett-1.4.11b.json"
+    },
+    {
+      "id": "nett-1.4.11c",
+      "file": "/Testreglar/1.4.11/Nett/nett-1.4.11c.json"
+    },
+    {
       "id": "app-1.4.2a",
       "file": "/Testreglar/1.4.2/App/app-1.4.2a.json"
     },
@@ -231,6 +239,22 @@
     {
       "id": "nett-1.4.13b",
       "file": "/Testreglar/1.4.13/Nett/nett-1.4.13b.json"
+    },
+    {
+      "id": "nett-1.4.4a",
+      "file": "/Testreglar/1.4.4/Nett/nett-1.4.4a.json"
+    },
+    {
+      "id": "1.4.2a",
+      "file": "/Testreglar/1.4.2/Nett/1.4.2a.json"
+    },
+    {
+      "id": "nett-1.4.2a",
+      "file": "/Testreglar/1.4.2/Nett/nett-1.4.2a.json"
+    },
+    {
+      "id": "app-1.4.4a",
+      "file": "/Testreglar/1.4.4/App/app-1.4.4a.json"
     },
     {
       "id": "1.4.3a",
@@ -253,36 +277,16 @@
       "file": "/Testreglar/1.4.3/Nett/nett-1.4.3b.json"
     },
     {
-      "id": "1.4.2a",
-      "file": "/Testreglar/1.4.2/Nett/1.4.2a.json"
-    },
-    {
-      "id": "nett-1.4.2a",
-      "file": "/Testreglar/1.4.2/Nett/nett-1.4.2a.json"
-    },
-    {
-      "id": "app-1.4.4a",
-      "file": "/Testreglar/1.4.4/App/app-1.4.4a.json"
-    },
-    {
       "id": "app-1.4.3a",
       "file": "/Testreglar/1.4.3/App/app-1.4.3a.json"
     },
     {
-      "id": "nett-1.4.12a",
-      "file": "/Testreglar/1.4.12/Nett/nett-1.4.12a.json"
+      "id": "app-2.1.1a",
+      "file": "/Testreglar/2.1.1/App/app-2.1.1a.json"
     },
     {
       "id": "app-1.4.5a",
       "file": "/Testreglar/1.4.5/App/app-1.4.5a.json"
-    },
-    {
-      "id": "nett-1.4.4a",
-      "file": "/Testreglar/1.4.4/Nett/nett-1.4.4a.json"
-    },
-    {
-      "id": "nett-2.1.1a",
-      "file": "/Testreglar/2.1.1/Nett/nett-2.1.1a.json"
     },
     {
       "id": "1.4.5a",
@@ -293,12 +297,32 @@
       "file": "/Testreglar/1.4.5/Nett/nett-1.4.5a.json"
     },
     {
-      "id": "app-2.1.1a",
-      "file": "/Testreglar/2.1.1/App/app-2.1.1a.json"
+      "id": "nett-2.1.1a",
+      "file": "/Testreglar/2.1.1/Nett/nett-2.1.1a.json"
+    },
+    {
+      "id": "nett-2.1.4a",
+      "file": "/Testreglar/2.1.4/Nett/nett-2.1.4a.json"
+    },
+    {
+      "id": "app-2.2.1a",
+      "file": "/Testreglar/2.2.1/App/app-2.2.1a.json"
     },
     {
       "id": "app-2.1.2a",
       "file": "/Testreglar/2.1.2/App/app-2.1.2a.json"
+    },
+    {
+      "id": "nett-2.1.2a",
+      "file": "/Testreglar/2.1.2/Nett/nett-2.1.2a.json"
+    },
+    {
+      "id": "app-2.2.2a",
+      "file": "/Testreglar/2.2.2/App/app-2.2.2a.json"
+    },
+    {
+      "id": "app-2.2.2b",
+      "file": "/Testreglar/2.2.2/App/app-2.2.2b.json"
     },
     {
       "id": "2.2.1a",
@@ -309,20 +333,12 @@
       "file": "/Testreglar/2.2.1/Nett/nett-2.2.1a.json"
     },
     {
-      "id": "nett-2.1.2a",
-      "file": "/Testreglar/2.1.2/Nett/nett-2.1.2a.json"
+      "id": "2.3.1a",
+      "file": "/Testreglar/2.3.1/Nett/2.3.1a.json"
     },
     {
-      "id": "nett-2.1.4a",
-      "file": "/Testreglar/2.1.4/Nett/nett-2.1.4a.json"
-    },
-    {
-      "id": "app-2.3.1a",
-      "file": "/Testreglar/2.3.1/App/app-2.3.1a.json"
-    },
-    {
-      "id": "app-2.2.1a",
-      "file": "/Testreglar/2.2.1/App/app-2.2.1a.json"
+      "id": "nett-2.3.1a",
+      "file": "/Testreglar/2.3.1/Nett/nett-2.3.1a.json"
     },
     {
       "id": "2.2.2a",
@@ -341,60 +357,8 @@
       "file": "/Testreglar/2.2.2/Nett/nett-2.2.2b.json"
     },
     {
-      "id": "2.3.1a",
-      "file": "/Testreglar/2.3.1/Nett/2.3.1a.json"
-    },
-    {
-      "id": "nett-2.3.1a",
-      "file": "/Testreglar/2.3.1/Nett/nett-2.3.1a.json"
-    },
-    {
-      "id": "app-2.2.2a",
-      "file": "/Testreglar/2.2.2/App/app-2.2.2a.json"
-    },
-    {
-      "id": "app-2.2.2b",
-      "file": "/Testreglar/2.2.2/App/app-2.2.2b.json"
-    },
-    {
-      "id": "app-2.4.4a",
-      "file": "/Testreglar/2.4.4/App/app-2.4.4a.json"
-    },
-    {
-      "id": "2.4.2a",
-      "file": "/Testreglar/2.4.2/Nett/2.4.2a.json"
-    },
-    {
-      "id": "nett-2.4.2a",
-      "file": "/Testreglar/2.4.2/Nett/nett-2.4.2a.json"
-    },
-    {
-      "id": "2.4.3a",
-      "file": "/Testreglar/2.4.3/Nett/2.4.3a.json"
-    },
-    {
-      "id": "nett-2.4.3a",
-      "file": "/Testreglar/2.4.3/Nett/nett-2.4.3a.json"
-    },
-    {
-      "id": "2.4.4a",
-      "file": "/Testreglar/2.4.4/Nett/2.4.4a.json"
-    },
-    {
-      "id": "nett-2.4.4a",
-      "file": "/Testreglar/2.4.4/Nett/nett-2.4.4a.json"
-    },
-    {
-      "id": "nett-2.4.7a",
-      "file": "/Testreglar/2.4.7/Nett/nett-2.4.7a.json"
-    },
-    {
-      "id": "2.4.5a",
-      "file": "/Testreglar/2.4.5/Nett/2.4.5a.json"
-    },
-    {
-      "id": "nett-2.4.5a",
-      "file": "/Testreglar/2.4.5/Nett/nett-2.4.5a.json"
+      "id": "app-2.3.1a",
+      "file": "/Testreglar/2.3.1/App/app-2.3.1a.json"
     },
     {
       "id": "2.4.1a",
@@ -405,8 +369,40 @@
       "file": "/Testreglar/2.4.1/Nett/nett-2.4.1a.json"
     },
     {
-      "id": "app-2.5.2a",
-      "file": "/Testreglar/2.5.2/App/app-2.5.2a.json"
+      "id": "2.4.2a",
+      "file": "/Testreglar/2.4.2/Nett/2.4.2a.json"
+    },
+    {
+      "id": "nett-2.4.2a",
+      "file": "/Testreglar/2.4.2/Nett/nett-2.4.2a.json"
+    },
+    {
+      "id": "app-2.4.4a",
+      "file": "/Testreglar/2.4.4/App/app-2.4.4a.json"
+    },
+    {
+      "id": "2.4.4a",
+      "file": "/Testreglar/2.4.4/Nett/2.4.4a.json"
+    },
+    {
+      "id": "nett-2.4.4a",
+      "file": "/Testreglar/2.4.4/Nett/nett-2.4.4a.json"
+    },
+    {
+      "id": "2.4.3a",
+      "file": "/Testreglar/2.4.3/Nett/2.4.3a.json"
+    },
+    {
+      "id": "nett-2.4.3a",
+      "file": "/Testreglar/2.4.3/Nett/nett-2.4.3a.json"
+    },
+    {
+      "id": "2.4.5a",
+      "file": "/Testreglar/2.4.5/Nett/2.4.5a.json"
+    },
+    {
+      "id": "nett-2.4.5a",
+      "file": "/Testreglar/2.4.5/Nett/nett-2.4.5a.json"
     },
     {
       "id": "app-2.4.6a",
@@ -417,12 +413,16 @@
       "file": "/Testreglar/2.4.6/App/app-2.4.6b.json"
     },
     {
+      "id": "app-2.5.1a",
+      "file": "/Testreglar/2.5.1/App/app-2.5.1a.json"
+    },
+    {
       "id": "nett-2.5.1a",
       "file": "/Testreglar/2.5.1/Nett/nett-2.5.1a.json"
     },
     {
-      "id": "nett-2.5.2a",
-      "file": "/Testreglar/2.5.2/Nett/nett-2.5.2a.json"
+      "id": "nett-2.4.7a",
+      "file": "/Testreglar/2.4.7/Nett/nett-2.4.7a.json"
     },
     {
       "id": "2.4.6a",
@@ -445,24 +445,20 @@
       "file": "/Testreglar/2.5.3/App/app-2.5.3a.json"
     },
     {
-      "id": "app-2.5.4a",
-      "file": "/Testreglar/2.5.4/App/app-2.5.4a.json"
+      "id": "app-2.5.2a",
+      "file": "/Testreglar/2.5.2/App/app-2.5.2a.json"
     },
     {
-      "id": "app-3.1.1a",
-      "file": "/Testreglar/3.1.1/App/app-3.1.1a.json"
-    },
-    {
-      "id": "app-2.5.1a",
-      "file": "/Testreglar/2.5.1/App/app-2.5.1a.json"
+      "id": "nett-2.5.3a",
+      "file": "/Testreglar/2.5.3/Nett/nett-2.5.3a.json"
     },
     {
       "id": "nett-2.5.4a",
       "file": "/Testreglar/2.5.4/Nett/nett-2.5.4a.json"
     },
     {
-      "id": "nett-2.5.3a",
-      "file": "/Testreglar/2.5.3/Nett/nett-2.5.3a.json"
+      "id": "app-2.5.4a",
+      "file": "/Testreglar/2.5.4/App/app-2.5.4a.json"
     },
     {
       "id": "3.1.1a",
@@ -471,6 +467,14 @@
     {
       "id": "nett-3.1.1a",
       "file": "/Testreglar/3.1.1/Nett/nett-3.1.1a.json"
+    },
+    {
+      "id": "app-3.1.1a",
+      "file": "/Testreglar/3.1.1/App/app-3.1.1a.json"
+    },
+    {
+      "id": "nett-2.5.2a",
+      "file": "/Testreglar/2.5.2/Nett/nett-2.5.2a.json"
     },
     {
       "id": "3.1.2a",
@@ -493,6 +497,14 @@
       "file": "/Testreglar/3.2.2/App/app-3.2.2a.json"
     },
     {
+      "id": "3.2.4a",
+      "file": "/Testreglar/3.2.4/Nett/3.2.4a.json"
+    },
+    {
+      "id": "nett-3.2.4a",
+      "file": "/Testreglar/3.2.4/Nett/nett-3.2.4a.json"
+    },
+    {
       "id": "3.2.2a",
       "file": "/Testreglar/3.2.2/Nett/3.2.2a.json"
     },
@@ -505,20 +517,12 @@
       "file": "/Testreglar/3.3.2/App/app-3.3.2a.json"
     },
     {
-      "id": "3.3.2a",
-      "file": "/Testreglar/3.3.2/Nett/3.3.2a.json"
+      "id": "3.2.3a",
+      "file": "/Testreglar/3.2.3/Nett/3.2.3a.json"
     },
     {
-      "id": "nett-3.3.2a",
-      "file": "/Testreglar/3.3.2/Nett/nett-3.3.2a.json"
-    },
-    {
-      "id": "3.2.4a",
-      "file": "/Testreglar/3.2.4/Nett/3.2.4a.json"
-    },
-    {
-      "id": "nett-3.2.4a",
-      "file": "/Testreglar/3.2.4/Nett/nett-3.2.4a.json"
+      "id": "nett-3.2.3a",
+      "file": "/Testreglar/3.2.3/Nett/nett-3.2.3a.json"
     },
     {
       "id": "app-3.3.1a-2022",
@@ -533,16 +537,12 @@
       "file": "/Testreglar/3.3.1/App/app-3.3.1b.json"
     },
     {
-      "id": "3.3.3a",
-      "file": "/Testreglar/3.3.3/Nett/3.3.3a.json"
+      "id": "3.3.2a",
+      "file": "/Testreglar/3.3.2/Nett/3.3.2a.json"
     },
     {
-      "id": "nett-3.3.3a",
-      "file": "/Testreglar/3.3.3/Nett/nett-3.3.3a.json"
-    },
-    {
-      "id": "app-4.1.2a",
-      "file": "/Testreglar/4.1.2/App/app-4.1.2a.json"
+      "id": "nett-3.3.2a",
+      "file": "/Testreglar/3.3.2/Nett/nett-3.3.2a.json"
     },
     {
       "id": "3.3.1a",
@@ -561,8 +561,52 @@
       "file": "/Testreglar/3.3.1/Nett/nett-3.3.1b.json"
     },
     {
+      "id": "4.1.1a",
+      "file": "/Testreglar/4.1.1/Nett/4.1.1a.json"
+    },
+    {
       "id": "app-3.3.3a",
       "file": "/Testreglar/3.3.3/App/app-3.3.3a.json"
+    },
+    {
+      "id": "3.3.3a",
+      "file": "/Testreglar/3.3.3/Nett/3.3.3a.json"
+    },
+    {
+      "id": "nett-3.3.3a",
+      "file": "/Testreglar/3.3.3/Nett/nett-3.3.3a.json"
+    },
+    {
+      "id": "app-3.3.4a",
+      "file": "/Testreglar/3.3.4/App/app-3.3.4a.json"
+    },
+    {
+      "id": "app-3.3.4b",
+      "file": "/Testreglar/3.3.4/App/app-3.3.4b.json"
+    },
+    {
+      "id": "3.3.4a",
+      "file": "/Testreglar/3.3.4/Nett/3.3.4a.json"
+    },
+    {
+      "id": "3.3.4b",
+      "file": "/Testreglar/3.3.4/Nett/3.3.4b.json"
+    },
+    {
+      "id": "nett-3.3.4a",
+      "file": "/Testreglar/3.3.4/Nett/nett-3.3.4a.json"
+    },
+    {
+      "id": "nett-3.3.4b",
+      "file": "/Testreglar/3.3.4/Nett/nett-3.3.4b.json"
+    },
+    {
+      "id": "app-4.1.2a",
+      "file": "/Testreglar/4.1.2/App/app-4.1.2a.json"
+    },
+    {
+      "id": "nett-4.1.3a",
+      "file": "/Testreglar/4.1.3/Nett/nett-4.1.3a.json"
     },
     {
       "id": "4.1.2a",
@@ -591,46 +635,6 @@
     {
       "id": "nett-4.1.2d",
       "file": "/Testreglar/4.1.2/Nett/nett-4.1.2d.json"
-    },
-    {
-      "id": "4.1.1a",
-      "file": "/Testreglar/4.1.1/Nett/4.1.1a.json"
-    },
-    {
-      "id": "3.3.4a",
-      "file": "/Testreglar/3.3.4/Nett/3.3.4a.json"
-    },
-    {
-      "id": "3.3.4b",
-      "file": "/Testreglar/3.3.4/Nett/3.3.4b.json"
-    },
-    {
-      "id": "nett-3.3.4a",
-      "file": "/Testreglar/3.3.4/Nett/nett-3.3.4a.json"
-    },
-    {
-      "id": "nett-3.3.4b",
-      "file": "/Testreglar/3.3.4/Nett/nett-3.3.4b.json"
-    },
-    {
-      "id": "app-3.3.4a",
-      "file": "/Testreglar/3.3.4/App/app-3.3.4a.json"
-    },
-    {
-      "id": "app-3.3.4b",
-      "file": "/Testreglar/3.3.4/App/app-3.3.4b.json"
-    },
-    {
-      "id": "3.2.3a",
-      "file": "/Testreglar/3.2.3/Nett/3.2.3a.json"
-    },
-    {
-      "id": "nett-3.2.3a",
-      "file": "/Testreglar/3.2.3/Nett/nett-3.2.3a.json"
-    },
-    {
-      "id": "nett-4.1.3a",
-      "file": "/Testreglar/4.1.3/Nett/nett-4.1.3a.json"
     }
   ],
   "utdaterte": [
@@ -651,6 +655,22 @@
       "file": "/Utdatert/2.4.7/2.4.7a.json"
     },
     {
+      "id": "app-1.1.1a-2022",
+      "file": "/Utdatert/1.1.1/App/app-1.1.1a-2022.json"
+    },
+    {
+      "id": "1.2.5a-2022",
+      "file": "/Utdatert/1.2.5/Nett/1.2.5a-2022.json"
+    },
+    {
+      "id": "1.4.10a-2022",
+      "file": "/Utdatert/1.4.10/Nett/1.4.10a-2022.json"
+    },
+    {
+      "id": "1.4.11a-2022",
+      "file": "/Utdatert/1.4.11/Nett/1.4.11a-2022.json"
+    },
+    {
       "id": "1.4.1a",
       "file": "/Utdatert/1.4.1/Nett/1.4.1a.json"
     },
@@ -663,28 +683,8 @@
       "file": "/Utdatert/1.4.1/Nett/1.4.1c.json"
     },
     {
-      "id": "app-1.1.1a-2022",
-      "file": "/Utdatert/1.1.1/App/app-1.1.1a-2022.json"
-    },
-    {
-      "id": "1.2.5a-2022",
-      "file": "/Utdatert/1.2.5/Nett/1.2.5a-2022.json"
-    },
-    {
       "id": "1.3.4a-2022",
       "file": "/Utdatert/1.3.4/Nett/1.3.4a-2022.json"
-    },
-    {
-      "id": "1.4.10a-2022",
-      "file": "/Utdatert/1.4.10/Nett/1.4.10a-2022.json"
-    },
-    {
-      "id": "1.4.11a-2022",
-      "file": "/Utdatert/1.4.11/Nett/1.4.11a-2022.json"
-    },
-    {
-      "id": "1.4.4a",
-      "file": "/Utdatert/1.4.4/Nett/1.4.4a.json"
     },
     {
       "id": "app-android-1.3.5a",
@@ -695,28 +695,32 @@
       "file": "/Utdatert/1.3.5/App/app-ios-1.3.5a.json"
     },
     {
-      "id": "2.1.2a",
-      "file": "/Utdatert/2.1.2/nett/2.1.2a.json"
-    },
-    {
-      "id": "2.1.4a-2022",
-      "file": "/Utdatert/2.1.4/Nett/2.1.4a-2022.json"
+      "id": "1.4.4a",
+      "file": "/Utdatert/1.4.4/Nett/1.4.4a.json"
     },
     {
       "id": "app-2.1.2a-2022",
       "file": "/Utdatert/2.1.2/app/app-2.1.2a-2022.json"
     },
     {
+      "id": "2.1.4a-2022",
+      "file": "/Utdatert/2.1.4/Nett/2.1.4a-2022.json"
+    },
+    {
+      "id": "2.1.2a",
+      "file": "/Utdatert/2.1.2/nett/2.1.2a.json"
+    },
+    {
       "id": "app-4.1.2a-2022",
       "file": "/Utdatert/4.1.2/App/app-4.1.2a-2022.json"
     },
     {
-      "id": "app-3.3.2a-2022",
-      "file": "/Utdatert/3.3.2/App/app-3.3.2a-2022.json"
-    },
-    {
       "id": "2.5.3a-2022",
       "file": "/Utdatert/2.5.3/Nett/2.5.3a-2022.json"
+    },
+    {
+      "id": "app-3.3.2a-2022",
+      "file": "/Utdatert/3.3.2/App/app-3.3.2a-2022.json"
     }
   ]
 }

--- a/index.json
+++ b/index.json
@@ -9,32 +9,8 @@
       "file": "/Testreglar/1.1.1/App/app-1.1.1f.json"
     },
     {
-      "id": "app-1.2.1a",
-      "file": "/Testreglar/1.2.1/App/app-1.2.1a.json"
-    },
-    {
-      "id": "app-1.2.1b",
-      "file": "/Testreglar/1.2.1/App/app-1.2.1b.json"
-    },
-    {
-      "id": "1.2.1a",
-      "file": "/Testreglar/1.2.1/Nett/1.2.1a.json"
-    },
-    {
-      "id": "1.2.1b",
-      "file": "/Testreglar/1.2.1/Nett/1.2.1b.json"
-    },
-    {
-      "id": "nett-1.2.1a",
-      "file": "/Testreglar/1.2.1/Nett/nett-1.2.1a.json"
-    },
-    {
-      "id": "nett-1.2.1b",
-      "file": "/Testreglar/1.2.1/Nett/nett-1.2.1b.json"
-    },
-    {
-      "id": "app-1.2.5a",
-      "file": "/Testreglar/1.2.5/App/app-1.2.5a.json"
+      "id": "app-1.2.2a",
+      "file": "/Testreglar/1.2.2/App/app-1.2.2a.json"
     },
     {
       "id": "1.1.1a",
@@ -73,10 +49,6 @@
       "file": "/Testreglar/1.1.1/Nett/nett-1.1.1f.json"
     },
     {
-      "id": "app-1.2.2a",
-      "file": "/Testreglar/1.2.2/App/app-1.2.2a.json"
-    },
-    {
       "id": "nett-1.2.5a",
       "file": "/Testreglar/1.2.5/Nett/nett-1.2.5a.json"
     },
@@ -89,24 +61,28 @@
       "file": "/Testreglar/1.2.2/Nett/nett-1.2.2a.json"
     },
     {
-      "id": "1.3.2a",
-      "file": "/Testreglar/1.3.2/Nett/1.3.2a.json"
+      "id": "1.2.1a",
+      "file": "/Testreglar/1.2.1/Nett/1.2.1a.json"
     },
     {
-      "id": "nett-1.3.2a",
-      "file": "/Testreglar/1.3.2/Nett/nett-1.3.2a.json"
+      "id": "1.2.1b",
+      "file": "/Testreglar/1.2.1/Nett/1.2.1b.json"
     },
     {
-      "id": "app-1.3.4a",
-      "file": "/Testreglar/1.3.4/App/app-1.3.4a.json"
+      "id": "nett-1.2.1a",
+      "file": "/Testreglar/1.2.1/Nett/nett-1.2.1a.json"
     },
     {
-      "id": "app-1.3.2a",
-      "file": "/Testreglar/1.3.2/App/app-1.3.2a.json"
+      "id": "nett-1.2.1b",
+      "file": "/Testreglar/1.2.1/Nett/nett-1.2.1b.json"
     },
     {
-      "id": "app-1.3.3a",
-      "file": "/Testreglar/1.3.3/App/app-1.3.3a.json"
+      "id": "app-1.2.1a",
+      "file": "/Testreglar/1.2.1/App/app-1.2.1a.json"
+    },
+    {
+      "id": "app-1.2.1b",
+      "file": "/Testreglar/1.2.1/App/app-1.2.1b.json"
     },
     {
       "id": "1.3.3a",
@@ -115,6 +91,14 @@
     {
       "id": "nett-1.3.3a",
       "file": "/Testreglar/1.3.3/Nett/nett-1.3.3a.json"
+    },
+    {
+      "id": "app-1.2.5a",
+      "file": "/Testreglar/1.2.5/App/app-1.2.5a.json"
+    },
+    {
+      "id": "app-1.3.3a",
+      "file": "/Testreglar/1.3.3/App/app-1.3.3a.json"
     },
     {
       "id": "app-1.3.5a",
@@ -129,16 +113,8 @@
       "file": "/Testreglar/1.3.1/App/app-1.3.1c.json"
     },
     {
-      "id": "nett-1.4.1a",
-      "file": "/Testreglar/1.4.1/Nett/nett-1.4.1a.json"
-    },
-    {
-      "id": "nett-1.4.1b",
-      "file": "/Testreglar/1.4.1/Nett/nett-1.4.1b.json"
-    },
-    {
-      "id": "nett-1.4.1c",
-      "file": "/Testreglar/1.4.1/Nett/nett-1.4.1c.json"
+      "id": "app-1.3.4a",
+      "file": "/Testreglar/1.3.4/App/app-1.3.4a.json"
     },
     {
       "id": "1.3.1a",
@@ -151,10 +127,6 @@
     {
       "id": "1.3.1c",
       "file": "/Testreglar/1.3.1/Nett/1.3.1c.json"
-    },
-    {
-      "id": "131a2025",
-      "file": "/Testreglar/1.3.1/Nett/131a2025.json"
     },
     {
       "id": "nett-1.3.1a",
@@ -181,6 +153,22 @@
       "file": "/Testreglar/1.3.1/Nett/nett-1.3.1f.json"
     },
     {
+      "id": "app-1.4.10a",
+      "file": "/Testreglar/1.4.10/App/app-1.4.10a.json"
+    },
+    {
+      "id": "app-1.3.2a",
+      "file": "/Testreglar/1.3.2/App/app-1.3.2a.json"
+    },
+    {
+      "id": "1.3.2a",
+      "file": "/Testreglar/1.3.2/Nett/1.3.2a.json"
+    },
+    {
+      "id": "nett-1.3.2a",
+      "file": "/Testreglar/1.3.2/Nett/nett-1.3.2a.json"
+    },
+    {
       "id": "app-1.4.1a",
       "file": "/Testreglar/1.4.1/App/app-1.4.1a.json"
     },
@@ -197,12 +185,28 @@
       "file": "/Testreglar/1.4.10/Nett/nett-1.4.10a.json"
     },
     {
-      "id": "nett-1.4.12a",
-      "file": "/Testreglar/1.4.12/Nett/nett-1.4.12a.json"
+      "id": "nett-1.4.11a",
+      "file": "/Testreglar/1.4.11/Nett/nett-1.4.11a.json"
     },
     {
-      "id": "app-1.4.10a",
-      "file": "/Testreglar/1.4.10/App/app-1.4.10a.json"
+      "id": "nett-1.4.11b",
+      "file": "/Testreglar/1.4.11/Nett/nett-1.4.11b.json"
+    },
+    {
+      "id": "nett-1.4.11c",
+      "file": "/Testreglar/1.4.11/Nett/nett-1.4.11c.json"
+    },
+    {
+      "id": "nett-1.4.1a",
+      "file": "/Testreglar/1.4.1/Nett/nett-1.4.1a.json"
+    },
+    {
+      "id": "nett-1.4.1b",
+      "file": "/Testreglar/1.4.1/Nett/nett-1.4.1b.json"
+    },
+    {
+      "id": "nett-1.4.1c",
+      "file": "/Testreglar/1.4.1/Nett/nett-1.4.1c.json"
     },
     {
       "id": "app-1.4.11a",
@@ -217,18 +221,6 @@
       "file": "/Testreglar/1.4.11/App/app-1.4.11c.json"
     },
     {
-      "id": "nett-1.4.11a",
-      "file": "/Testreglar/1.4.11/Nett/nett-1.4.11a.json"
-    },
-    {
-      "id": "nett-1.4.11b",
-      "file": "/Testreglar/1.4.11/Nett/nett-1.4.11b.json"
-    },
-    {
-      "id": "nett-1.4.11c",
-      "file": "/Testreglar/1.4.11/Nett/nett-1.4.11c.json"
-    },
-    {
       "id": "app-1.4.2a",
       "file": "/Testreglar/1.4.2/App/app-1.4.2a.json"
     },
@@ -239,22 +231,6 @@
     {
       "id": "nett-1.4.13b",
       "file": "/Testreglar/1.4.13/Nett/nett-1.4.13b.json"
-    },
-    {
-      "id": "nett-1.4.4a",
-      "file": "/Testreglar/1.4.4/Nett/nett-1.4.4a.json"
-    },
-    {
-      "id": "1.4.2a",
-      "file": "/Testreglar/1.4.2/Nett/1.4.2a.json"
-    },
-    {
-      "id": "nett-1.4.2a",
-      "file": "/Testreglar/1.4.2/Nett/nett-1.4.2a.json"
-    },
-    {
-      "id": "app-1.4.4a",
-      "file": "/Testreglar/1.4.4/App/app-1.4.4a.json"
     },
     {
       "id": "1.4.3a",
@@ -277,16 +253,36 @@
       "file": "/Testreglar/1.4.3/Nett/nett-1.4.3b.json"
     },
     {
+      "id": "1.4.2a",
+      "file": "/Testreglar/1.4.2/Nett/1.4.2a.json"
+    },
+    {
+      "id": "nett-1.4.2a",
+      "file": "/Testreglar/1.4.2/Nett/nett-1.4.2a.json"
+    },
+    {
+      "id": "app-1.4.4a",
+      "file": "/Testreglar/1.4.4/App/app-1.4.4a.json"
+    },
+    {
       "id": "app-1.4.3a",
       "file": "/Testreglar/1.4.3/App/app-1.4.3a.json"
     },
     {
-      "id": "app-2.1.1a",
-      "file": "/Testreglar/2.1.1/App/app-2.1.1a.json"
+      "id": "nett-1.4.12a",
+      "file": "/Testreglar/1.4.12/Nett/nett-1.4.12a.json"
     },
     {
       "id": "app-1.4.5a",
       "file": "/Testreglar/1.4.5/App/app-1.4.5a.json"
+    },
+    {
+      "id": "nett-1.4.4a",
+      "file": "/Testreglar/1.4.4/Nett/nett-1.4.4a.json"
+    },
+    {
+      "id": "nett-2.1.1a",
+      "file": "/Testreglar/2.1.1/Nett/nett-2.1.1a.json"
     },
     {
       "id": "1.4.5a",
@@ -297,32 +293,12 @@
       "file": "/Testreglar/1.4.5/Nett/nett-1.4.5a.json"
     },
     {
-      "id": "nett-2.1.1a",
-      "file": "/Testreglar/2.1.1/Nett/nett-2.1.1a.json"
-    },
-    {
-      "id": "nett-2.1.4a",
-      "file": "/Testreglar/2.1.4/Nett/nett-2.1.4a.json"
-    },
-    {
-      "id": "app-2.2.1a",
-      "file": "/Testreglar/2.2.1/App/app-2.2.1a.json"
+      "id": "app-2.1.1a",
+      "file": "/Testreglar/2.1.1/App/app-2.1.1a.json"
     },
     {
       "id": "app-2.1.2a",
       "file": "/Testreglar/2.1.2/App/app-2.1.2a.json"
-    },
-    {
-      "id": "nett-2.1.2a",
-      "file": "/Testreglar/2.1.2/Nett/nett-2.1.2a.json"
-    },
-    {
-      "id": "app-2.2.2a",
-      "file": "/Testreglar/2.2.2/App/app-2.2.2a.json"
-    },
-    {
-      "id": "app-2.2.2b",
-      "file": "/Testreglar/2.2.2/App/app-2.2.2b.json"
     },
     {
       "id": "2.2.1a",
@@ -333,12 +309,20 @@
       "file": "/Testreglar/2.2.1/Nett/nett-2.2.1a.json"
     },
     {
-      "id": "2.3.1a",
-      "file": "/Testreglar/2.3.1/Nett/2.3.1a.json"
+      "id": "nett-2.1.2a",
+      "file": "/Testreglar/2.1.2/Nett/nett-2.1.2a.json"
     },
     {
-      "id": "nett-2.3.1a",
-      "file": "/Testreglar/2.3.1/Nett/nett-2.3.1a.json"
+      "id": "nett-2.1.4a",
+      "file": "/Testreglar/2.1.4/Nett/nett-2.1.4a.json"
+    },
+    {
+      "id": "app-2.3.1a",
+      "file": "/Testreglar/2.3.1/App/app-2.3.1a.json"
+    },
+    {
+      "id": "app-2.2.1a",
+      "file": "/Testreglar/2.2.1/App/app-2.2.1a.json"
     },
     {
       "id": "2.2.2a",
@@ -357,16 +341,24 @@
       "file": "/Testreglar/2.2.2/Nett/nett-2.2.2b.json"
     },
     {
-      "id": "app-2.3.1a",
-      "file": "/Testreglar/2.3.1/App/app-2.3.1a.json"
+      "id": "2.3.1a",
+      "file": "/Testreglar/2.3.1/Nett/2.3.1a.json"
     },
     {
-      "id": "2.4.1a",
-      "file": "/Testreglar/2.4.1/Nett/2.4.1a.json"
+      "id": "nett-2.3.1a",
+      "file": "/Testreglar/2.3.1/Nett/nett-2.3.1a.json"
     },
     {
-      "id": "nett-2.4.1a",
-      "file": "/Testreglar/2.4.1/Nett/nett-2.4.1a.json"
+      "id": "app-2.2.2a",
+      "file": "/Testreglar/2.2.2/App/app-2.2.2a.json"
+    },
+    {
+      "id": "app-2.2.2b",
+      "file": "/Testreglar/2.2.2/App/app-2.2.2b.json"
+    },
+    {
+      "id": "app-2.4.4a",
+      "file": "/Testreglar/2.4.4/App/app-2.4.4a.json"
     },
     {
       "id": "2.4.2a",
@@ -377,8 +369,12 @@
       "file": "/Testreglar/2.4.2/Nett/nett-2.4.2a.json"
     },
     {
-      "id": "app-2.4.4a",
-      "file": "/Testreglar/2.4.4/App/app-2.4.4a.json"
+      "id": "2.4.3a",
+      "file": "/Testreglar/2.4.3/Nett/2.4.3a.json"
+    },
+    {
+      "id": "nett-2.4.3a",
+      "file": "/Testreglar/2.4.3/Nett/nett-2.4.3a.json"
     },
     {
       "id": "2.4.4a",
@@ -389,12 +385,8 @@
       "file": "/Testreglar/2.4.4/Nett/nett-2.4.4a.json"
     },
     {
-      "id": "2.4.3a",
-      "file": "/Testreglar/2.4.3/Nett/2.4.3a.json"
-    },
-    {
-      "id": "nett-2.4.3a",
-      "file": "/Testreglar/2.4.3/Nett/nett-2.4.3a.json"
+      "id": "nett-2.4.7a",
+      "file": "/Testreglar/2.4.7/Nett/nett-2.4.7a.json"
     },
     {
       "id": "2.4.5a",
@@ -405,6 +397,18 @@
       "file": "/Testreglar/2.4.5/Nett/nett-2.4.5a.json"
     },
     {
+      "id": "2.4.1a",
+      "file": "/Testreglar/2.4.1/Nett/2.4.1a.json"
+    },
+    {
+      "id": "nett-2.4.1a",
+      "file": "/Testreglar/2.4.1/Nett/nett-2.4.1a.json"
+    },
+    {
+      "id": "app-2.5.2a",
+      "file": "/Testreglar/2.5.2/App/app-2.5.2a.json"
+    },
+    {
       "id": "app-2.4.6a",
       "file": "/Testreglar/2.4.6/App/app-2.4.6a.json"
     },
@@ -413,16 +417,12 @@
       "file": "/Testreglar/2.4.6/App/app-2.4.6b.json"
     },
     {
-      "id": "app-2.5.1a",
-      "file": "/Testreglar/2.5.1/App/app-2.5.1a.json"
-    },
-    {
       "id": "nett-2.5.1a",
       "file": "/Testreglar/2.5.1/Nett/nett-2.5.1a.json"
     },
     {
-      "id": "nett-2.4.7a",
-      "file": "/Testreglar/2.4.7/Nett/nett-2.4.7a.json"
+      "id": "nett-2.5.2a",
+      "file": "/Testreglar/2.5.2/Nett/nett-2.5.2a.json"
     },
     {
       "id": "2.4.6a",
@@ -445,20 +445,24 @@
       "file": "/Testreglar/2.5.3/App/app-2.5.3a.json"
     },
     {
-      "id": "app-2.5.2a",
-      "file": "/Testreglar/2.5.2/App/app-2.5.2a.json"
+      "id": "app-2.5.4a",
+      "file": "/Testreglar/2.5.4/App/app-2.5.4a.json"
     },
     {
-      "id": "nett-2.5.3a",
-      "file": "/Testreglar/2.5.3/Nett/nett-2.5.3a.json"
+      "id": "app-3.1.1a",
+      "file": "/Testreglar/3.1.1/App/app-3.1.1a.json"
+    },
+    {
+      "id": "app-2.5.1a",
+      "file": "/Testreglar/2.5.1/App/app-2.5.1a.json"
     },
     {
       "id": "nett-2.5.4a",
       "file": "/Testreglar/2.5.4/Nett/nett-2.5.4a.json"
     },
     {
-      "id": "app-2.5.4a",
-      "file": "/Testreglar/2.5.4/App/app-2.5.4a.json"
+      "id": "nett-2.5.3a",
+      "file": "/Testreglar/2.5.3/Nett/nett-2.5.3a.json"
     },
     {
       "id": "3.1.1a",
@@ -467,14 +471,6 @@
     {
       "id": "nett-3.1.1a",
       "file": "/Testreglar/3.1.1/Nett/nett-3.1.1a.json"
-    },
-    {
-      "id": "app-3.1.1a",
-      "file": "/Testreglar/3.1.1/App/app-3.1.1a.json"
-    },
-    {
-      "id": "nett-2.5.2a",
-      "file": "/Testreglar/2.5.2/Nett/nett-2.5.2a.json"
     },
     {
       "id": "3.1.2a",
@@ -497,14 +493,6 @@
       "file": "/Testreglar/3.2.2/App/app-3.2.2a.json"
     },
     {
-      "id": "3.2.4a",
-      "file": "/Testreglar/3.2.4/Nett/3.2.4a.json"
-    },
-    {
-      "id": "nett-3.2.4a",
-      "file": "/Testreglar/3.2.4/Nett/nett-3.2.4a.json"
-    },
-    {
       "id": "3.2.2a",
       "file": "/Testreglar/3.2.2/Nett/3.2.2a.json"
     },
@@ -517,12 +505,20 @@
       "file": "/Testreglar/3.3.2/App/app-3.3.2a.json"
     },
     {
-      "id": "3.2.3a",
-      "file": "/Testreglar/3.2.3/Nett/3.2.3a.json"
+      "id": "3.3.2a",
+      "file": "/Testreglar/3.3.2/Nett/3.3.2a.json"
     },
     {
-      "id": "nett-3.2.3a",
-      "file": "/Testreglar/3.2.3/Nett/nett-3.2.3a.json"
+      "id": "nett-3.3.2a",
+      "file": "/Testreglar/3.3.2/Nett/nett-3.3.2a.json"
+    },
+    {
+      "id": "3.2.4a",
+      "file": "/Testreglar/3.2.4/Nett/3.2.4a.json"
+    },
+    {
+      "id": "nett-3.2.4a",
+      "file": "/Testreglar/3.2.4/Nett/nett-3.2.4a.json"
     },
     {
       "id": "app-3.3.1a-2022",
@@ -537,12 +533,16 @@
       "file": "/Testreglar/3.3.1/App/app-3.3.1b.json"
     },
     {
-      "id": "3.3.2a",
-      "file": "/Testreglar/3.3.2/Nett/3.3.2a.json"
+      "id": "3.3.3a",
+      "file": "/Testreglar/3.3.3/Nett/3.3.3a.json"
     },
     {
-      "id": "nett-3.3.2a",
-      "file": "/Testreglar/3.3.2/Nett/nett-3.3.2a.json"
+      "id": "nett-3.3.3a",
+      "file": "/Testreglar/3.3.3/Nett/nett-3.3.3a.json"
+    },
+    {
+      "id": "app-4.1.2a",
+      "file": "/Testreglar/4.1.2/App/app-4.1.2a.json"
     },
     {
       "id": "3.3.1a",
@@ -561,52 +561,8 @@
       "file": "/Testreglar/3.3.1/Nett/nett-3.3.1b.json"
     },
     {
-      "id": "4.1.1a",
-      "file": "/Testreglar/4.1.1/Nett/4.1.1a.json"
-    },
-    {
       "id": "app-3.3.3a",
       "file": "/Testreglar/3.3.3/App/app-3.3.3a.json"
-    },
-    {
-      "id": "3.3.3a",
-      "file": "/Testreglar/3.3.3/Nett/3.3.3a.json"
-    },
-    {
-      "id": "nett-3.3.3a",
-      "file": "/Testreglar/3.3.3/Nett/nett-3.3.3a.json"
-    },
-    {
-      "id": "app-3.3.4a",
-      "file": "/Testreglar/3.3.4/App/app-3.3.4a.json"
-    },
-    {
-      "id": "app-3.3.4b",
-      "file": "/Testreglar/3.3.4/App/app-3.3.4b.json"
-    },
-    {
-      "id": "3.3.4a",
-      "file": "/Testreglar/3.3.4/Nett/3.3.4a.json"
-    },
-    {
-      "id": "3.3.4b",
-      "file": "/Testreglar/3.3.4/Nett/3.3.4b.json"
-    },
-    {
-      "id": "nett-3.3.4a",
-      "file": "/Testreglar/3.3.4/Nett/nett-3.3.4a.json"
-    },
-    {
-      "id": "nett-3.3.4b",
-      "file": "/Testreglar/3.3.4/Nett/nett-3.3.4b.json"
-    },
-    {
-      "id": "app-4.1.2a",
-      "file": "/Testreglar/4.1.2/App/app-4.1.2a.json"
-    },
-    {
-      "id": "nett-4.1.3a",
-      "file": "/Testreglar/4.1.3/Nett/nett-4.1.3a.json"
     },
     {
       "id": "4.1.2a",
@@ -635,6 +591,46 @@
     {
       "id": "nett-4.1.2d",
       "file": "/Testreglar/4.1.2/Nett/nett-4.1.2d.json"
+    },
+    {
+      "id": "4.1.1a",
+      "file": "/Testreglar/4.1.1/Nett/4.1.1a.json"
+    },
+    {
+      "id": "3.3.4a",
+      "file": "/Testreglar/3.3.4/Nett/3.3.4a.json"
+    },
+    {
+      "id": "3.3.4b",
+      "file": "/Testreglar/3.3.4/Nett/3.3.4b.json"
+    },
+    {
+      "id": "nett-3.3.4a",
+      "file": "/Testreglar/3.3.4/Nett/nett-3.3.4a.json"
+    },
+    {
+      "id": "nett-3.3.4b",
+      "file": "/Testreglar/3.3.4/Nett/nett-3.3.4b.json"
+    },
+    {
+      "id": "app-3.3.4a",
+      "file": "/Testreglar/3.3.4/App/app-3.3.4a.json"
+    },
+    {
+      "id": "app-3.3.4b",
+      "file": "/Testreglar/3.3.4/App/app-3.3.4b.json"
+    },
+    {
+      "id": "3.2.3a",
+      "file": "/Testreglar/3.2.3/Nett/3.2.3a.json"
+    },
+    {
+      "id": "nett-3.2.3a",
+      "file": "/Testreglar/3.2.3/Nett/nett-3.2.3a.json"
+    },
+    {
+      "id": "nett-4.1.3a",
+      "file": "/Testreglar/4.1.3/Nett/nett-4.1.3a.json"
     }
   ],
   "utdaterte": [
@@ -655,22 +651,6 @@
       "file": "/Utdatert/2.4.7/2.4.7a.json"
     },
     {
-      "id": "app-1.1.1a-2022",
-      "file": "/Utdatert/1.1.1/App/app-1.1.1a-2022.json"
-    },
-    {
-      "id": "1.2.5a-2022",
-      "file": "/Utdatert/1.2.5/Nett/1.2.5a-2022.json"
-    },
-    {
-      "id": "1.4.10a-2022",
-      "file": "/Utdatert/1.4.10/Nett/1.4.10a-2022.json"
-    },
-    {
-      "id": "1.4.11a-2022",
-      "file": "/Utdatert/1.4.11/Nett/1.4.11a-2022.json"
-    },
-    {
       "id": "1.4.1a",
       "file": "/Utdatert/1.4.1/Nett/1.4.1a.json"
     },
@@ -683,8 +663,28 @@
       "file": "/Utdatert/1.4.1/Nett/1.4.1c.json"
     },
     {
+      "id": "app-1.1.1a-2022",
+      "file": "/Utdatert/1.1.1/App/app-1.1.1a-2022.json"
+    },
+    {
+      "id": "1.2.5a-2022",
+      "file": "/Utdatert/1.2.5/Nett/1.2.5a-2022.json"
+    },
+    {
       "id": "1.3.4a-2022",
       "file": "/Utdatert/1.3.4/Nett/1.3.4a-2022.json"
+    },
+    {
+      "id": "1.4.10a-2022",
+      "file": "/Utdatert/1.4.10/Nett/1.4.10a-2022.json"
+    },
+    {
+      "id": "1.4.11a-2022",
+      "file": "/Utdatert/1.4.11/Nett/1.4.11a-2022.json"
+    },
+    {
+      "id": "1.4.4a",
+      "file": "/Utdatert/1.4.4/Nett/1.4.4a.json"
     },
     {
       "id": "app-android-1.3.5a",
@@ -695,32 +695,28 @@
       "file": "/Utdatert/1.3.5/App/app-ios-1.3.5a.json"
     },
     {
-      "id": "1.4.4a",
-      "file": "/Utdatert/1.4.4/Nett/1.4.4a.json"
-    },
-    {
-      "id": "app-2.1.2a-2022",
-      "file": "/Utdatert/2.1.2/app/app-2.1.2a-2022.json"
+      "id": "2.1.2a",
+      "file": "/Utdatert/2.1.2/nett/2.1.2a.json"
     },
     {
       "id": "2.1.4a-2022",
       "file": "/Utdatert/2.1.4/Nett/2.1.4a-2022.json"
     },
     {
-      "id": "2.1.2a",
-      "file": "/Utdatert/2.1.2/nett/2.1.2a.json"
+      "id": "app-2.1.2a-2022",
+      "file": "/Utdatert/2.1.2/app/app-2.1.2a-2022.json"
     },
     {
       "id": "app-4.1.2a-2022",
       "file": "/Utdatert/4.1.2/App/app-4.1.2a-2022.json"
     },
     {
-      "id": "2.5.3a-2022",
-      "file": "/Utdatert/2.5.3/Nett/2.5.3a-2022.json"
-    },
-    {
       "id": "app-3.3.2a-2022",
       "file": "/Utdatert/3.3.2/App/app-3.3.2a-2022.json"
+    },
+    {
+      "id": "2.5.3a-2022",
+      "file": "/Utdatert/2.5.3/Nett/2.5.3a-2022.json"
     }
   ]
 }


### PR DESCRIPTION
3.3 Utfall for brudd endret, routet til 3.5 for å ignorere «andre måter å ivareta formattering på» Dette er i tolkning, men hvorfor? Tar en avklaring med jurist
3.7 Fjernet merknad, ingen forstod den.
3.7 Lagt til Aria-level OG overskrifthierarki=brudd uavhengig. DU kan bruke role=heading utan aria-level men dette gir automatisk brudd i hierarki.
Ruting endret for mer effektiv testing
Endret navn