### PR TITLE
App-2.5.3a Synlig ledetekst er en del av tilgjengelig navn 2025

### DIFF
--- a/Testreglar/2.5.3/App/253aApp2025.json
+++ b/Testreglar/2.5.3/App/253aApp2025.json
@@ -1,114 +1,114 @@
 {
-    "namn": "App-2.5.3a Synlig ledetekst er en del av tilgjengelig navn 2025",
-    "id": "253aApp2025",
-    "testlabId": 603,
-    "versjon": "1.0",
-    "type": "App",
-    "spraak": "nb",
-    "kravTilSamsvar": "<p>For brukergrensesnittkomponenter med ledetekster som inneholder tekst eller bilder av tekst, som støtter tilgjengelig navn, gjelder en av følgende:</p><ul><li>Synlig (visuell) ledetekst og tilgjengelig navn (accessible name) er identiske eller</li><li>Tilgjengelig navn (accessible name) inneholder samme tekst, i samme rekkefølge som synlig (visuell) ledetekst </li></ul>",
-    "side": "2.1",
-    "element": "3.1",
-    "steg": [
-        {
-            "stegnr": "2.1",
-            "spm": "Hvilken appside tester du?",
-            "ht": "<p>Oppgi appside-ID.</p>",
-            "type": "tekst",
-            "kilde": [],
-            "label": "Appside:",
-            "datalist": "Sideutvalg",
-            "ruting": {
-                "alle": {
-                    "type": "gaaTil",
-                    "steg": "2.2"
-                }
-            }
-        },
-        {
-            "stegnr": "2.2",
-            "spm": "Har appsiden brukergrensesnittkomponenter med synlig ledetekst som inneholder tekst eller bilde av tekst?",
-            "ht": "<ul><li>Gjennomfør en visuell inspeksjon</li></ul><p>Synlig ledetekst til brukergrensesnittkomponenten kan bestå av</p><ul><li>bare tekst</li><li>bilde av tekst brukt som symbol, for eksempel<ul><li>Der bokstavene F, K og U brukes i et tekstredigeringsverktøy som symbol for fet, kursiv og understreket tekst</li></ul></li></ul><p><strong>Merk:</strong> Når synlig ledetekst mangler skal placeholdertekst i tekstfelt testes som ledetekst. Dette gjelder kun i relasjon til testregel 2.5.3.</p>",
-            "type": "jaNei",
-            "ruting": {
-                "ja": {
-                    "type": "gaaTil",
-                    "steg": "3.1"
-                },
-                "nei": {
-                    "type": "ikkjeForekomst",
-                    "utfall": "Appsiden har ikke brukergrensesnittkomponenter med synlig ledetekst som består av tekst eller bilde av tekst."
-                }
-            }
-        },
-        {
-            "stegnr": "3.1",
-            "spm": "Hvilken brukergrensesnittkomponent tester du?",
-            "ht": "<ul><li>Beskriv brukergrensesnittkomponentet</li><li>Beskriv plassering</li></ul><p><strong>Merk: </strong>Hvis det er flere brukergrensesnittkomponent på siden, registrerer du ett og ett brukergrensesnittkomponent</p>",
-            "type": "tekst",
-            "label": "Brukergrensesnittkomponent:",
-            "multilinje": true,
-            "ruting": {
-                "alle": {
-                    "type": "gaaTil",
-                    "steg": "3.2"
-                }
-            }
-        },
-        {
-            "stegnr": "3.2",
-            "spm": "Ligger synlig ledetekst i, rett ved siden av eller under brukergrensesnittkomponenten?",
-            "ht": "<p>Du skal ikke vurdere:</p><ul><li>gruppeledetekst for skjemaelementer i grupper</li><li>instruksjoner</li><li>overskrifter</li></ul>",
-            "type": "jaNei",
-            "ruting": {
-                "ja": {
-                    "type": "gaaTil",
-                    "steg": "3.4"
-                },
-                "nei": {
-                    "type": "ikkjeForekomst",
-                    "utfall": "Brukergrensesnittkomponenten har ikke synlig ledetekst som ligger i, rett ved siden av eller under."
-                }
-            }
-        },
-        {
-            "stegnr": "3.4",
-            "spm": "Har brukergrensesnittkomponenten et tilgjengelig navn, som ikke er tomt?",
-            "ht": "<ul><li>Aktiver skjermleser<ul><li>iOS: VoiceOver</li><li>Android: TalkBack</li></ul></li><li>Trykk på eller sveip til brukergrensesnittkomponenten du tester, sjekk om du får lest opp tilgjengelig navn</li></ul><p><strong>Merk: </strong> Skjermleseren kan lese opp tilleggsinformasjon som ikke er en del av det tilgjengelige navnet, for eksempel rolle, men du skal kun vurdere det tilgjengelige navnet.</p>",
-            "type": "jaNei",
-            "ruting": {
-                "ja": {
-                    "type": "gaaTil",
-                    "steg": "3.5"
-                },
-                "nei": {
-                    "type": "avslutt",
-                    "fasit": "Nei",
-                    "utfall": "Brukergrensesnittkomponenten med synlig ledetekst har ikke tilgjengelig navn."
-                }
-            }
-        },
-        {
-            "stegnr": "3.5",
-            "spm": "Inneholder tilgjengelig navn for komponenten samme tekst, i samme rekkefølge, som den synlige ledeteksten?",
-            "ht": "<p><strong>Merk:</strong> Du kan se vekk fra følgende i vurderingen av tilgjengelig navn </p><ul><li>store og små bokstaver</li><li>Tilsvarende formuleringer som søk i synlig ledetekst og søkefelt i programatisk bestemt ledetekst.</li><li>tegnsetting, for eksempel kolon og punktum<ul><li>Eksempel: Synlig ledetekst er Fornavn:  </li><li>Tilgjengelig navn er \"fornavn\"</li><li>Kravet er oppfylt selv om tilgjengelig navn ikke inneholder stor bokstav og kolon</li></ul></li></ul><p><strong>Merk:</strong></p><ul><li><strong>Matematiske symboler og formler:</strong> Tilgjengelig navn skal være identisk med den synlige ledeteksten.<ul><li>Eksempel: Radioknapper med synlige ledetekster A&gt;B, A=B, A&lt;B. Tilgjengelig navn til de samme radioknappene skal være \"A&gt;B\", \"A=B\", \"A&lt;B\". </li></ul></li><li><strong>Symbolske teksttegn:</strong> Når tekst eller bilde av tekst brukes som symbol, er det funksjonen til det symbolske teksttegnet, som skal avspeiles i tilgjengelig navn.<ul><li>Eksempel<ul><li>Bokstavene <strong>F</strong>, <em>K</em> og <span style=\"text-decoration: underline;\">U</span> brukes i et tekstredigeringsverktøy som symbol for fet, kursiv og understreket tekst. Tilgjengelig navn kan være \"fet\", \"kursiv\" og \"understreket\" eller tilsvarende</li><li>Bokstaven X brukes som symbol for å lukke et vindu eller en dialogboks. Tilgjengelig navn kan være \"Lukk\" eller tilsvarende.</li></ul></li></ul></li></ul>",
-            "type": "jaNei",
-            "kilde": [
-                "F96",
-                "G208",
-                "G211"
-            ],
-            "ruting": {
-                "ja": {
-                    "type": "avslutt",
-                    "fasit": "Ja",
-                    "utfall": "Brukergrensesnittkomponenten med synlig ledetekst som ligger rett ved siden av, har tilgjengelig navn i samme rekkefølge som den synlige ledeteksten."
-                },
-                "nei": {
-                    "type": "avslutt",
-                    "fasit": "Nei",
-                    "utfall": "Brukergrensesnittkomponenten med synlig ledetekst som ligger rett ved siden av, har ikke tilgjengelig navn i samme rekkefølge som den synlige ledeteksten."
-                }
-            }
-        }
-    ]
+	"namn": "App-2.5.3a Synlig ledetekst er en del av tilgjengelig navn 2025",
+	"id": "253aApp2025",
+	"testlabId": 603,
+	"versjon": "1.0",
+	"type": "App",
+	"spraak": "nb",
+	"kravTilSamsvar": "<p>For brukergrensesnittkomponenter med ledetekster som inneholder tekst eller bilder av tekst, som ligger rett ved siden av eller i nær tilknytning til brukergrensesnittkomponenten og som støtter tilgjengelig navn, gjelder en av følgende:</p><ul><li>Synlig (visuell) ledetekst og tilgjengelig navn (accessible name) er identiske.</li><li>Tilgjengelig navn (accessible name) inneholder eller starter med samme tekst, i samme rekkefølge som synlig (visuell) ledetekst.</li></ul>",
+	"side": "2.1",
+	"element": "3.1",
+	"steg": [
+		{
+			"stegnr": "2.1",
+			"spm": "Hvilken appside tester du?",
+			"ht": "<p>Oppgi appside-ID.</p>",
+			"type": "tekst",
+			"kilde": [],
+			"label": "Appside:",
+			"datalist": "Sideutvalg",
+			"ruting": {
+				"alle": {
+					"type": "gaaTil",
+					"steg": "2.2"
+				}
+			}
+		},
+		{
+			"stegnr": "2.2",
+			"spm": "Har appsiden brukergrensesnittkomponenter med synlig ledetekst som inneholder tekst eller bilde av tekst?",
+			"ht": "<ul><li>Gjennomfør en visuell inspeksjon</li></ul><p>Synlig ledetekst til brukergrensesnittkomponenten kan bestå av</p><ul><li>bare tekst</li><li>bilde av tekst brukt som symbol, for eksempel<ul><li>Der bokstavene F, K og U brukes i et tekstredigeringsverktøy som symbol for fet, kursiv og understreket tekst</li></ul></li></ul><p><strong>Merk:</strong> Når synlig ledetekst mangler skal placeholdertekst i tekstfelt testes som ledetekst. Dette gjelder kun i relasjon til testregel 2.5.3.</p>",
+			"type": "jaNei",
+			"ruting": {
+				"ja": {
+					"type": "gaaTil",
+					"steg": "3.1"
+				},
+				"nei": {
+					"type": "ikkjeForekomst",
+					"utfall": "Appsiden har ikke brukergrensesnittkomponenter med synlig ledetekst som består av tekst eller bilde av tekst."
+				}
+			}
+		},
+		{
+			"stegnr": "3.1",
+			"spm": "Hvilken brukergrensesnittkomponent tester du?",
+			"ht": "<ul><li>Beskriv brukergrensesnittkomponentet</li><li>Beskriv plassering</li></ul><p><strong>Merk: </strong>Hvis det er flere brukergrensesnittkomponent på siden, registrerer du ett og ett brukergrensesnittkomponent</p>",
+			"type": "tekst",
+			"label": "Brukergrensesnittkomponent:",
+			"multilinje": true,
+			"ruting": {
+				"alle": {
+					"type": "gaaTil",
+					"steg": "3.2"
+				}
+			}
+		},
+		{
+			"stegnr": "3.2",
+			"spm": "Ligger synlig ledetekst i, rett ved siden av eller under brukergrensesnittkomponenten?",
+			"ht": "<p>Du skal ikke vurdere:</p><ul><li>gruppeledetekst for skjemaelementer i grupper</li><li>instruksjoner</li><li>overskrifter</li></ul>",
+			"type": "jaNei",
+			"ruting": {
+				"ja": {
+					"type": "gaaTil",
+					"steg": "3.4"
+				},
+				"nei": {
+					"type": "ikkjeForekomst",
+					"utfall": "Brukergrensesnittkomponenten har ikke synlig ledetekst som ligger i, rett ved siden av eller under."
+				}
+			}
+		},
+		{
+			"stegnr": "3.4",
+			"spm": "Har brukergrensesnittkomponenten et tilgjengelig navn, som ikke er tomt?",
+			"ht": "<ul><li>Aktiver skjermleser<ul><li>iOS: VoiceOver</li><li>Android: TalkBack</li></ul></li><li>Trykk på eller sveip til brukergrensesnittkomponenten du tester, sjekk om du får lest opp tilgjengelig navn</li></ul><p><strong>Merk: </strong> Skjermleseren kan lese opp tilleggsinformasjon som ikke er en del av det tilgjengelige navnet, for eksempel rolle, men du skal kun vurdere det tilgjengelige navnet.</p>",
+			"type": "jaNei",
+			"ruting": {
+				"ja": {
+					"type": "gaaTil",
+					"steg": "3.5"
+				},
+				"nei": {
+					"type": "avslutt",
+					"fasit": "Nei",
+					"utfall": "Brukergrensesnittkomponenten med synlig ledetekst har ikke tilgjengelig navn."
+				}
+			}
+		},
+		{
+			"stegnr": "3.5",
+			"spm": "Inneholder tilgjengelig navn for komponenten samme, eller starter med den synlige ledeteksten, i samme rekkefølge?",
+			"ht": "<p><strong>Merk:</strong> Du kan se vekk fra følgende i vurderingen av tilgjengelig navn </p><ul><li>store og små bokstaver</li><li>Tilsvarende formuleringer som søk i synlig ledetekst og søkefelt i programatisk bestemt ledetekst.</li><li>tegnsetting, for eksempel kolon og punktum<ul><li>Eksempel: Synlig ledetekst er Fornavn:  </li><li>Tilgjengelig navn er \"fornavn\"</li><li>Kravet er oppfylt selv om tilgjengelig navn ikke inneholder stor bokstav og kolon</li></ul></li></ul><p><strong>Merk:</strong></p><ul><li><strong>Matematiske symboler og formler:</strong> Tilgjengelig navn skal være identisk med den synlige ledeteksten.<ul><li>Eksempel: Radioknapper med synlige ledetekster A&gt;B, A=B, A&lt;B. Tilgjengelig navn til de samme radioknappene skal være \"A&gt;B\", \"A=B\", \"A&lt;B\". </li></ul></li><li><strong>Symbolske teksttegn:</strong> Når tekst eller bilde av tekst brukes som symbol, er det funksjonen til det symbolske teksttegnet, som skal avspeiles i tilgjengelig navn.<ul><li>Eksempel<ul><li>Bokstavene <strong>F</strong>, <em>K</em> og <span style=\"text-decoration: underline;\">U</span> brukes i et tekstredigeringsverktøy som symbol for fet, kursiv og understreket tekst. Tilgjengelig navn kan være \"fet\", \"kursiv\" og \"understreket\" eller tilsvarende</li><li>Bokstaven X brukes som symbol for å lukke et vindu eller en dialogboks. Tilgjengelig navn kan være \"Lukk\" eller tilsvarende.</li></ul></li></ul></li></ul>",
+			"type": "jaNei",
+			"kilde": [
+				"F96",
+				"G208",
+				"G211"
+			],
+			"ruting": {
+				"ja": {
+					"type": "avslutt",
+					"fasit": "Ja",
+					"utfall": "Brukergrensesnittkomponenten med synlig ledetekst som ligger rett ved siden av, har tilgjengelig navn i samme rekkefølge som den synlige ledeteksten."
+				},
+				"nei": {
+					"type": "avslutt",
+					"fasit": "Nei",
+					"utfall": "Brukergrensesnittkomponenten med synlig ledetekst som ligger rett ved siden av, har ikke tilgjengelig navn i samme rekkefølge som den synlige ledeteksten."
+				}
+			}
+		}
+	]
 }

--- a/Testreglar/2.5.3/App/253aApp2025.json
+++ b/Testreglar/2.5.3/App/253aApp2025.json
@@ -62,7 +62,7 @@
 			"ruting": {
 				"ja": {
 					"type": "gaaTil",
-					"steg": "3.4"
+					"steg": "3.3"
 				},
 				"nei": {
 					"type": "ikkjeForekomst",
@@ -71,14 +71,14 @@
 			}
 		},
 		{
-			"stegnr": "3.4",
+			"stegnr": "3.3",
 			"spm": "Har brukergrensesnittkomponenten et tilgjengelig navn, som ikke er tomt?",
 			"ht": "<ul><li>Aktiver skjermleser<ul><li>iOS: VoiceOver</li><li>Android: TalkBack</li></ul></li><li>Trykk på eller sveip til brukergrensesnittkomponenten du tester, sjekk om du får lest opp tilgjengelig navn</li></ul><p><strong>Merk: </strong> Skjermleseren kan lese opp tilleggsinformasjon som ikke er en del av det tilgjengelige navnet, for eksempel rolle, men du skal kun vurdere det tilgjengelige navnet.</p>",
 			"type": "jaNei",
 			"ruting": {
 				"ja": {
 					"type": "gaaTil",
-					"steg": "3.5"
+					"steg": "3.4"
 				},
 				"nei": {
 					"type": "avslutt",
@@ -88,7 +88,7 @@
 			}
 		},
 		{
-			"stegnr": "3.5",
+			"stegnr": "3.4",
 			"spm": "Inneholder tilgjengelig navn for komponenten samme, eller starter med den synlige ledeteksten, i samme rekkefølge?",
 			"ht": "<p><strong>Merk:</strong> Du kan se vekk fra følgende i vurderingen av tilgjengelig navn </p><ul><li>store og små bokstaver</li><li>Tilsvarende formuleringer som søk i synlig ledetekst og søkefelt i programatisk bestemt ledetekst.</li><li>tegnsetting, for eksempel kolon og punktum<ul><li>Eksempel: Synlig ledetekst er Fornavn:  </li><li>Tilgjengelig navn er \"fornavn\"</li><li>Kravet er oppfylt selv om tilgjengelig navn ikke inneholder stor bokstav og kolon</li></ul></li></ul><p><strong>Merk:</strong></p><ul><li><strong>Matematiske symboler og formler:</strong> Tilgjengelig navn skal være identisk med den synlige ledeteksten.<ul><li>Eksempel: Radioknapper med synlige ledetekster A&gt;B, A=B, A&lt;B. Tilgjengelig navn til de samme radioknappene skal være \"A&gt;B\", \"A=B\", \"A&lt;B\". </li></ul></li><li><strong>Symbolske teksttegn:</strong> Når tekst eller bilde av tekst brukes som symbol, er det funksjonen til det symbolske teksttegnet, som skal avspeiles i tilgjengelig navn.<ul><li>Eksempel<ul><li>Bokstavene <strong>F</strong>, <em>K</em> og <span style=\"text-decoration: underline;\">U</span> brukes i et tekstredigeringsverktøy som symbol for fet, kursiv og understreket tekst. Tilgjengelig navn kan være \"fet\", \"kursiv\" og \"understreket\" eller tilsvarende</li><li>Bokstaven X brukes som symbol for å lukke et vindu eller en dialogboks. Tilgjengelig navn kan være \"Lukk\" eller tilsvarende.</li></ul></li></ul></li></ul>",
 			"type": "jaNei",

--- a/Testreglar/2.5.3/App/253aApp2025.json
+++ b/Testreglar/2.5.3/App/253aApp2025.json
@@ -1,0 +1,114 @@
+{
+    "namn": "App-2.5.3a Synlig ledetekst er en del av tilgjengelig navn 2025",
+    "id": "253aApp2025",
+    "testlabId": 603,
+    "versjon": "1.0",
+    "type": "App",
+    "spraak": "nb",
+    "kravTilSamsvar": "<p>For brukergrensesnittkomponenter med ledetekster som inneholder tekst eller bilder av tekst, som støtter tilgjengelig navn, gjelder en av følgende:</p><ul><li>Synlig (visuell) ledetekst og tilgjengelig navn (accessible name) er identiske eller</li><li>Tilgjengelig navn (accessible name) inneholder samme tekst, i samme rekkefølge som synlig (visuell) ledetekst </li></ul>",
+    "side": "2.1",
+    "element": "3.1",
+    "steg": [
+        {
+            "stegnr": "2.1",
+            "spm": "Hvilken appside tester du?",
+            "ht": "<p>Oppgi appside-ID.</p>",
+            "type": "tekst",
+            "kilde": [],
+            "label": "Appside:",
+            "datalist": "Sideutvalg",
+            "ruting": {
+                "alle": {
+                    "type": "gaaTil",
+                    "steg": "2.2"
+                }
+            }
+        },
+        {
+            "stegnr": "2.2",
+            "spm": "Har appsiden brukergrensesnittkomponenter med synlig ledetekst som inneholder tekst eller bilde av tekst?",
+            "ht": "<ul><li>Gjennomfør en visuell inspeksjon</li></ul><p>Synlig ledetekst til brukergrensesnittkomponenten kan bestå av</p><ul><li>bare tekst</li><li>bilde av tekst brukt som symbol, for eksempel<ul><li>Der bokstavene F, K og U brukes i et tekstredigeringsverktøy som symbol for fet, kursiv og understreket tekst</li></ul></li></ul><p><strong>Merk:</strong> Når synlig ledetekst mangler skal placeholdertekst i tekstfelt testes som ledetekst. Dette gjelder kun i relasjon til testregel 2.5.3.</p>",
+            "type": "jaNei",
+            "ruting": {
+                "ja": {
+                    "type": "gaaTil",
+                    "steg": "3.1"
+                },
+                "nei": {
+                    "type": "ikkjeForekomst",
+                    "utfall": "Appsiden har ikke brukergrensesnittkomponenter med synlig ledetekst som består av tekst eller bilde av tekst."
+                }
+            }
+        },
+        {
+            "stegnr": "3.1",
+            "spm": "Hvilken brukergrensesnittkomponent tester du?",
+            "ht": "<ul><li>Beskriv brukergrensesnittkomponentet</li><li>Beskriv plassering</li></ul><p><strong>Merk: </strong>Hvis det er flere brukergrensesnittkomponent på siden, registrerer du ett og ett brukergrensesnittkomponent</p>",
+            "type": "tekst",
+            "label": "Brukergrensesnittkomponent:",
+            "multilinje": true,
+            "ruting": {
+                "alle": {
+                    "type": "gaaTil",
+                    "steg": "3.2"
+                }
+            }
+        },
+        {
+            "stegnr": "3.2",
+            "spm": "Ligger synlig ledetekst i, rett ved siden av eller under brukergrensesnittkomponenten?",
+            "ht": "<p>Du skal ikke vurdere:</p><ul><li>gruppeledetekst for skjemaelementer i grupper</li><li>instruksjoner</li><li>overskrifter</li></ul>",
+            "type": "jaNei",
+            "ruting": {
+                "ja": {
+                    "type": "gaaTil",
+                    "steg": "3.4"
+                },
+                "nei": {
+                    "type": "ikkjeForekomst",
+                    "utfall": "Brukergrensesnittkomponenten har ikke synlig ledetekst som ligger i, rett ved siden av eller under."
+                }
+            }
+        },
+        {
+            "stegnr": "3.4",
+            "spm": "Har brukergrensesnittkomponenten et tilgjengelig navn, som ikke er tomt?",
+            "ht": "<ul><li>Aktiver skjermleser<ul><li>iOS: VoiceOver</li><li>Android: TalkBack</li></ul></li><li>Trykk på eller sveip til brukergrensesnittkomponenten du tester, sjekk om du får lest opp tilgjengelig navn</li></ul><p><strong>Merk: </strong> Skjermleseren kan lese opp tilleggsinformasjon som ikke er en del av det tilgjengelige navnet, for eksempel rolle, men du skal kun vurdere det tilgjengelige navnet.</p>",
+            "type": "jaNei",
+            "ruting": {
+                "ja": {
+                    "type": "gaaTil",
+                    "steg": "3.5"
+                },
+                "nei": {
+                    "type": "avslutt",
+                    "fasit": "Nei",
+                    "utfall": "Brukergrensesnittkomponenten med synlig ledetekst har ikke tilgjengelig navn."
+                }
+            }
+        },
+        {
+            "stegnr": "3.5",
+            "spm": "Inneholder tilgjengelig navn for komponenten samme tekst, i samme rekkefølge, som den synlige ledeteksten?",
+            "ht": "<p><strong>Merk:</strong> Du kan se vekk fra følgende i vurderingen av tilgjengelig navn </p><ul><li>store og små bokstaver</li><li>Tilsvarende formuleringer som søk i synlig ledetekst og søkefelt i programatisk bestemt ledetekst.</li><li>tegnsetting, for eksempel kolon og punktum<ul><li>Eksempel: Synlig ledetekst er Fornavn:  </li><li>Tilgjengelig navn er \"fornavn\"</li><li>Kravet er oppfylt selv om tilgjengelig navn ikke inneholder stor bokstav og kolon</li></ul></li></ul><p><strong>Merk:</strong></p><ul><li><strong>Matematiske symboler og formler:</strong> Tilgjengelig navn skal være identisk med den synlige ledeteksten.<ul><li>Eksempel: Radioknapper med synlige ledetekster A&gt;B, A=B, A&lt;B. Tilgjengelig navn til de samme radioknappene skal være \"A&gt;B\", \"A=B\", \"A&lt;B\". </li></ul></li><li><strong>Symbolske teksttegn:</strong> Når tekst eller bilde av tekst brukes som symbol, er det funksjonen til det symbolske teksttegnet, som skal avspeiles i tilgjengelig navn.<ul><li>Eksempel<ul><li>Bokstavene <strong>F</strong>, <em>K</em> og <span style=\"text-decoration: underline;\">U</span> brukes i et tekstredigeringsverktøy som symbol for fet, kursiv og understreket tekst. Tilgjengelig navn kan være \"fet\", \"kursiv\" og \"understreket\" eller tilsvarende</li><li>Bokstaven X brukes som symbol for å lukke et vindu eller en dialogboks. Tilgjengelig navn kan være \"Lukk\" eller tilsvarende.</li></ul></li></ul></li></ul>",
+            "type": "jaNei",
+            "kilde": [
+                "F96",
+                "G208",
+                "G211"
+            ],
+            "ruting": {
+                "ja": {
+                    "type": "avslutt",
+                    "fasit": "Ja",
+                    "utfall": "Brukergrensesnittkomponenten med synlig ledetekst som ligger rett ved siden av, har tilgjengelig navn i samme rekkefølge som den synlige ledeteksten."
+                },
+                "nei": {
+                    "type": "avslutt",
+                    "fasit": "Nei",
+                    "utfall": "Brukergrensesnittkomponenten med synlig ledetekst som ligger rett ved siden av, har ikke tilgjengelig navn i samme rekkefølge som den synlige ledeteksten."
+                }
+            }
+        }
+    ]
+}


### PR DESCRIPTION
Endret registrering til standarisert format
2.2 Fjernet: 
•	Forstørrelsesglass symbol for søkefelt
•	Hjertesymbol for funksjonen favoritt
Enten må dette begrunnes eller så er det fjernet. Står ikke i tolkning og gir ikke mening med tanke på at dette ikke er synlig ledetekst. 2.2 fjernet: Merk: Skjema i PDF, Word eller liknende, er ikke aktuelle testobjekt. Dette er en nettregel. 3.2 Endret Ligger synlig ledetekst rett i, rett ved siden av eller under brukergrensesnittkomponenten? For å ha med at den kan ligge flere steder enn rett ved siden av •	Tatt bort: rett til høyre for avkryssingsbokser og radioknapper •	i lenker, faner, knapper eller rett under ikon eller bilde av tekst som fungerer som knapper •	placeholdertekst i tekstfelt - Merk: Dette gjelder kun i relasjon til 2.5.3, når synlig ledetekst mangler. Fjernet steg 3.3. 
Steg 3.5 Inneholder tilgjengelig navn for komponenten samme eller tilsvarende tekst, i samme rekkefølge, som den synlige ledeteksten?
 Lagt til (eller tilsvarende) for å ha med når meningen er ivaretatt på tilsvarende måte.
Fjernet: Sammenlign og sjekk om
•	Synlig ledetekst og tilgjengelig navn er identiske eller •	Tilgjengelig navn inneholder samme tekst, i samme rekkefølge som synlig ledetekst
 Dette blir allerede spurt om i spørsmålet
•	Unicode emojis brukes til å uttrykke følelser osv. Tilgjengelig navn skal avspeile følelsen eller lignende. Tilgjengelig navn kan være smiler, ler, sint, hjerte, jogger, kyss, sol osv. Fjernet, unicode emojier er verken tekst eller bilde av tekst og skal ikke testes i dette kravet. •	Lagt til: Tilsvarende formuleringer som søk i synlig ledetekst og søkefelt i programatisk bestemt ledetekst. Dette skal gi samme funksjon eller? Endret utfall til:
•	Ja: Brukergrensesnittkomponenten med synlig ledetekst som ligger i, rett ved siden av eller under, har tilgjengelig navn i samme rekkefølge som den synlige ledeteksten. •	Nei: Brukergrensesnittkomponenten med synlig ledetekst som ligger i, rett ved siden av eller under, har ikke tilgjengelig navn i samme rekkefølge som den synlige ledeteksten.