### PR TITLE
Nett-3.3.1a Skjema gir feilmelding hvis tomme obligatoriske skjemafel…

### DIFF
--- a/Testreglar/3.3.1/Nett/331aNett2025.json
+++ b/Testreglar/3.3.1/Nett/331aNett2025.json
@@ -1,169 +1,169 @@
 {
-    "namn": "Nett-3.3.1a Skjema gir feilmelding hvis tomme obligatoriske skjemafelt blir oppdaget automatisk 2025",
-    "id": "331aNett2025",
-    "testlabId": 607,
-    "versjon": "1.0",
-    "type": "Nett",
-    "spraak": "nb",
-    "kravTilSamsvar": "<p>Dersom det blir oppdaget automatisk at obligatoriske skjemaelement ikke er fylt ut, er følgende tre punkter oppfylt:</p><ul><li>Skjemaelementet der feilen oppstod identifiseres.</li><li>Brukeren får en presis tekstlig beskrivelse av feilen.</li><li>Feilmeldingen er kodet som tekst.</li></ul>",
-    "side": "2.1",
-    "element": "3.1",
-    "steg": [
-        {
-            "stegnr": "2.1",
-            "spm": "Hvilken side tester du?",
-            "ht": "<p>Angi URL eller side-ID.</p>",
-            "type": "tekst",
-            "label": "URL/Side-ID:",
-            "datalist": "Sideutvalg",
-            "oblig": true,
-            "ruting": {
-                "alle": {
-                    "type": "gaaTil",
-                    "steg": "2.2"
-                }
-            }
-        },
-        {
-            "stegnr": "2.2",
-            "spm": "Har testsiden skjema?",
-            "ht": "",
-            "type": "jaNei",
-            "ruting": {
-                "ja": {
-                    "type": "gaaTil",
-                    "steg": "2.3"
-                },
-                "nei": {
-                    "type": "ikkjeForekomst",
-                    "utfall": "Testsiden har ikke skjema."
-                }
-            }
-        },
-        {
-            "stegnr": "2.3",
-            "spm": "Hvilket skjema tester du?",
-            "ht": "<ul><li>beskriv skjema</li><li>beskriv plassering</li></ul><p><strong>Merk:</strong></p><ul><li>Hvis skjema inngår i en prosess, skal du også beskrive prosessen.</li><li>Hvis det gjelder flere elementer, registrerer du ett og ett.</li></ul>",
-            "type": "tekst",
-            "label": "Skjema/prosess:",
-            "multilinje": true,
-            "oblig": true,
-            "ruting": {
-                "alle": {
-                    "type": "gaaTil",
-                    "steg": "2.4"
-                }
-            }
-        },
-        {
-            "stegnr": "2.4",
-            "spm": "Oppdager skjemaet automatisk at obligatoriske skjemaelement er tomme?",
-            "ht": "<ul><li>Ikke fyll ut informasjon i skjemaet (tomt skjema), eller</li><li>la alle obligatoriske skjemaelementer stå tomme, eller</li><li>fjern forhåndsutfylt informasjon (hvis mulig):<ul><li>Forhåndsutfylt informasjon betyr at det allerede står inndata i skjemaet når testsiden er lastet inn.</li><li>For eksempel informasjon hentet fra folkeregisteret som personnummer, fornavn, etternavn og adresse. </li></ul></li><li>Fullfør, send inn eller gå videre i skjemaet, for å sjekke om tomme obligatoriske skjemaelementer blir oppdaget automatisk.</li></ul><p><strong>Merk: </strong></p><ul><li>Begrepet \"oppdages automatisk\" betyr at skjemaet er satt opp slik at det selv oppdager når det mangler nødvendig informasjon i obligatoriske elementer i skjemaet. For eksempel med bruk av attributtene<code> required </code>eller <code>aria-required=\"true\"</code>.</li><li>Skjema der knappen for å gå videre eller fullføre er deaktivert, skal testes.<ul><li>Et deaktivert skjemaelement for å gå videre eller fullføre skjemaet, som blir aktivt når brukeren fyller ut rett informasjon, indikerer at brukeren har utelatt inndata som nettsiden krever, og at dette oppdages automatisk, uten at brukeren er involvert.</li></ul></li></ul>",
-            "type": "jaNei",
-            "ruting": {
-                "nei": {
-                    "type": "ikkjeForekomst",
-                    "utfall": "Skjema oppdager ikke automatisk at obligatoriske skjemaelementer er tomme.",
-                    "element": "2.3"
-                },
-                "ja": {
-                    "type": "gaaTil",
-                    "steg": "3.1"
-                }
-            }
-        },
-        {
-            "stegnr": "3.1",
-            "spm": "Hvilket obligatorisk skjemaelement tester du?",
-            "ht": "<ul><li>Beskriv skjemaelementet</li><li>Beskriv plassering</li></ul><p><strong>Merk: </strong>Hvis det gjelder flere elementer, registrerer du ett og ett.</p>",
-            "type": "tekst",
-            "label": "Skjemaelement:",
-            "multilinje": true,
-            "oblig": true,
-            "ruting": {
-                "alle": {
-                    "type": "gaaTil",
-                    "steg": "3.2"
-                }
-            }
-        },
-        {
-            "stegnr": "3.2",
-            "spm": "Får du en tekstlig feilmelding?",
-            "ht": "<p>Feilmeldingen kan for eksempel vises</p><ul><li>i et modalvindu</li><li>i ledeteksten til skjemaelementet</li><li>øverst på siden</li><li>når du navigerer i skjemaet</li></ul><p><strong>Merk:</strong> Feilmeldingen må være tekstlig, og det er ikke tilstrekkelig å identifisere feilen med et symbol, endret farge, visuell plassering, deaktivert innsendingsknapp eller lignende ikke-tekstlige indikatorer.</p>",
-            "type": "jaNei",
-            "kilde": [
-                "G83"
-            ],
-            "ruting": {
-                "ja": {
-                    "type": "gaaTil",
-                    "steg": "3.3"
-                },
-                "nei": {
-                    "type": "avslutt",
-                    "fasit": "Nei",
-                    "utfall": "Tomme obligatoriske skjemaelement, som blir oppdaget automatisk, får ikke tekstlig feilmelding."
-                }
-            }
-        },
-        {
-            "stegnr": "3.3",
-            "spm": "Er feilmeldingen kodet som tekst?",
-            "ht": "<ul><li>Prøv å markere teksten med mus eller tastatur, eller bruk kodeverktøyet i nettleseren for å sjekke om teksten er kodet som tekst.</li></ul><p><strong>Merk: </strong>Dersom skjemaelementet har attributtet <code>\"required\"</code> eller <code>aria-required=\"true\"</code>, kommer det fram en melding i nettleseren. Denne meldingen er kodet som tekst.</p>",
-            "type": "jaNei",
-            "ruting": {
-                "ja": {
-                    "type": "gaaTil",
-                    "steg": "3.4"
-                },
-                "nei": {
-                    "type": "avslutt",
-                    "fasit": "Nei",
-                    "utfall": "Tomme obligatoriske skjemaelement, som blir oppdaget automatisk, får feilmelding, men den er ikke kodet som tekst."
-                }
-            }
-        },
-        {
-            "stegnr": "3.4",
-            "spm": "Inneholder feilmeldingen tekst som identifiserer hvilket skjemaelement som er tomt?",
-            "ht": "",
-            "type": "jaNei",
-            "kilde": [
-                "G83"
-            ],
-            "ruting": {
-                "ja": {
-                    "type": "gaaTil",
-                    "steg": "3.5"
-                },
-                "nei": {
-                    "type": "avslutt",
-                    "fasit": "Nei",
-                    "utfall": "Tomme obligatoriske skjemaelement, som blir oppdaget automatisk får feilmelding som er kodet som tekst, men identifiserer ikke hvilket skjemaelement som er tomt."
-                }
-            }
-        },
-        {
-            "stegnr": "3.5",
-            "spm": "Inneholder feilmeldingen informasjon om hva som er feil?",
-            "ht": "<p>For eksempel:</p><ul><li>«Fornavn må fylles ut».</li></ul><p><strong>Merk:</strong> Krav om at feilmeldingen skal inneholde forslag til hvordan feil skal rettes, er omfattet av suksesskriterium 3.3.3.</p>",
-            "type": "jaNei",
-            "kilde": [
-                "G83"
-            ],
-            "ruting": {
-                "ja": {
-                    "type": "avslutt",
-                    "fasit": "Ja",
-                    "utfall": "Tomme obligatoriske skjemaelement, som blir oppdaget automatisk, får feilmelding som<br/>- er kodet som tekst<br/>- identifiserer hvilket skjemaelement som er tomt<br/>- inneholder informasjon om hva som er feil"
-                },
-                "nei": {
-                    "type": "avslutt",
-                    "fasit": "Nei",
-                    "utfall": "Tomme obligatoriske skjemaelement, som blir oppdaget automatisk, får feilmelding som<br/>- er kodet som tekst<br/>- identifiserer hvilket skjemaelement som er tomt<br/>- inneholder ikke informasjon om hva som er feil"
-                }
-            }
-        }
-    ]
+	"namn": "Nett-3.3.1a Skjema gir feilmelding hvis tomme obligatoriske skjemafelt blir oppdaget automatisk 2025",
+	"id": "331aNett2025",
+	"testlabId": 607,
+	"versjon": "1.0",
+	"type": "Nett",
+	"spraak": "nb",
+	"kravTilSamsvar": "<p>Dersom det blir oppdaget automatisk at obligatoriske skjemaelement ikke er fylt ut, er følgende tre punkter oppfylt:</p><ul><li>Skjemaelementet der feilen oppstod identifiseres.</li><li>Brukeren får en presis tekstlig beskrivelse av feilen.</li><li>Feilmeldingen er kodet som tekst.</li></ul>",
+	"side": "2.1",
+	"element": "3.1",
+	"steg": [
+		{
+			"stegnr": "2.1",
+			"spm": "Hvilken side tester du?",
+			"ht": "<p>Angi URL eller side-ID.</p>",
+			"type": "tekst",
+			"label": "URL/Side-ID:",
+			"datalist": "Sideutvalg",
+			"oblig": true,
+			"ruting": {
+				"alle": {
+					"type": "gaaTil",
+					"steg": "2.2"
+				}
+			}
+		},
+		{
+			"stegnr": "2.2",
+			"spm": "Har testsiden skjema?",
+			"ht": "",
+			"type": "jaNei",
+			"ruting": {
+				"ja": {
+					"type": "gaaTil",
+					"steg": "2.3"
+				},
+				"nei": {
+					"type": "ikkjeForekomst",
+					"utfall": "Testsiden har ikke skjema."
+				}
+			}
+		},
+		{
+			"stegnr": "2.3",
+			"spm": "Hvilket skjema tester du?",
+			"ht": "<ul><li>beskriv skjema</li><li>beskriv plassering</li></ul><p><strong>Merk:</strong></p><ul><li>Hvis skjema inngår i en prosess, skal du også beskrive prosessen.</li><li>Hvis det gjelder flere elementer, registrerer du ett og ett.</li></ul>",
+			"type": "tekst",
+			"label": "Skjema/prosess:",
+			"multilinje": true,
+			"oblig": true,
+			"ruting": {
+				"alle": {
+					"type": "gaaTil",
+					"steg": "2.4"
+				}
+			}
+		},
+		{
+			"stegnr": "2.4",
+			"spm": "Oppdager skjemaet automatisk at obligatoriske skjemaelement er tomme?",
+			"ht": "<ul><li>Ikke fyll ut informasjon i skjemaet (tomt skjema), eller</li><li>la alle obligatoriske skjemaelementer stå tomme, eller</li><li>fjern forhåndsutfylt informasjon (hvis mulig):<ul><li>Forhåndsutfylt informasjon betyr at det allerede står inndata i skjemaet når testsiden er lastet inn.</li><li>For eksempel informasjon hentet fra folkeregisteret som personnummer, fornavn, etternavn og adresse. </li></ul></li><li>Fullfør, send inn eller gå videre i skjemaet, for å sjekke om tomme obligatoriske skjemaelementer blir oppdaget automatisk.</li></ul><p><strong>Merk: </strong></p><ul><li>Begrepet \"oppdages automatisk\" betyr at skjemaet er satt opp slik at det selv oppdager når det mangler nødvendig informasjon i obligatoriske elementer i skjemaet. For eksempel med bruk av attributtene<code> required </code>eller <code>aria-required=\"true\"</code>.</li><li>Skjema der knappen for å gå videre eller fullføre er deaktivert, skal testes.<ul><li>Et deaktivert skjemaelement for å gå videre eller fullføre skjemaet, som blir aktivt når brukeren fyller ut rett informasjon, indikerer at brukeren har utelatt inndata som nettsiden krever, og at dette oppdages automatisk, uten at brukeren er involvert.</li></ul></li></ul>",
+			"type": "jaNei",
+			"ruting": {
+				"nei": {
+					"type": "ikkjeForekomst",
+					"utfall": "Skjema oppdager ikke automatisk at obligatoriske skjemaelementer er tomme.",
+					"element": "2.3"
+				},
+				"ja": {
+					"type": "gaaTil",
+					"steg": "3.1"
+				}
+			}
+		},
+		{
+			"stegnr": "3.1",
+			"spm": "Hvilket obligatorisk skjemaelement tester du?",
+			"ht": "<ul><li>Beskriv skjemaelementet</li><li>Beskriv plassering</li></ul><p><strong>Merk: </strong>Hvis det gjelder flere elementer, registrerer du ett og ett.</p>",
+			"type": "tekst",
+			"label": "Skjemaelement:",
+			"multilinje": true,
+			"oblig": true,
+			"ruting": {
+				"alle": {
+					"type": "gaaTil",
+					"steg": "3.2"
+				}
+			}
+		},
+		{
+			"stegnr": "3.2",
+			"spm": "Får du en tekstlig feilmelding?",
+			"ht": "<p>Feilmeldingen kan for eksempel vises</p><ul><li>i et modalvindu</li><li>i ledeteksten til skjemaelementet</li><li>øverst på siden</li><li>når du navigerer i skjemaet</li></ul><p><strong>Merk:</strong> Feilmeldingen må være tekstlig, og det er ikke tilstrekkelig å identifisere feilen med et symbol, endret farge, visuell plassering, deaktivert innsendingsknapp eller lignende ikke-tekstlige indikatorer.</p>",
+			"type": "jaNei",
+			"kilde": [
+				"G83"
+			],
+			"ruting": {
+				"ja": {
+					"type": "gaaTil",
+					"steg": "3.3"
+				},
+				"nei": {
+					"type": "avslutt",
+					"fasit": "Nei",
+					"utfall": "Tomme obligatoriske skjemaelement, som blir oppdaget automatisk, får ikke tekstlig feilmelding."
+				}
+			}
+		},
+		{
+			"stegnr": "3.3",
+			"spm": "Er feilmeldingen kodet som tekst?",
+			"ht": "<ul><li>Prøv å markere teksten med mus eller tastatur, eller bruk kodeverktøyet i nettleseren for å sjekke om teksten er kodet som tekst.</li></ul><p><strong>Merk: </strong>Dersom skjemaelementet har attributtet <code>\"required\"</code> eller <code>aria-required=\"true\"</code>, kommer det fram en melding i nettleseren. Denne meldingen er kodet som tekst.</p>",
+			"type": "jaNei",
+			"ruting": {
+				"ja": {
+					"type": "gaaTil",
+					"steg": "3.4"
+				},
+				"nei": {
+					"type": "avslutt",
+					"fasit": "Nei",
+					"utfall": "Tomme obligatoriske skjemaelement, som blir oppdaget automatisk, får feilmelding, men den er ikke kodet som tekst."
+				}
+			}
+		},
+		{
+			"stegnr": "3.4",
+			"spm": "Inneholder feilmeldingen tekst som identifiserer hvilket skjemaelement som er tomt?",
+			"ht": "",
+			"type": "jaNei",
+			"kilde": [
+				"G83"
+			],
+			"ruting": {
+				"ja": {
+					"type": "gaaTil",
+					"steg": "3.5"
+				},
+				"nei": {
+					"type": "avslutt",
+					"fasit": "Nei",
+					"utfall": "Tomme obligatoriske skjemaelement, som blir oppdaget automatisk får feilmelding som er kodet som tekst, men identifiserer ikke hvilket skjemaelement som er tomt."
+				}
+			}
+		},
+		{
+			"stegnr": "3.5",
+			"spm": "Inneholder feilmeldingen informasjon om hva som er feil?",
+			"ht": "<p>For eksempel:</p><ul><li>«Fornavn må fylles ut».</li></ul><p><strong>Merk:</strong> Krav om at feilmeldingen skal inneholde forslag til hvordan feil skal rettes, er omfattet av suksesskriterium 3.3.3.</p>",
+			"type": "jaNei",
+			"kilde": [
+				"G83"
+			],
+			"ruting": {
+				"ja": {
+					"type": "avslutt",
+					"fasit": "Ja",
+					"utfall": "Tomme obligatoriske skjemaelement, som blir oppdaget automatisk, får feilmelding som<br/>- er kodet som tekst<br/>- identifiserer hvilket skjemaelement som er tomt<br/>- inneholder informasjon om hva som er feil"
+				},
+				"nei": {
+					"type": "avslutt",
+					"fasit": "Nei",
+					"utfall": "Tomme obligatoriske skjemaelement, som blir oppdaget automatisk, får feilmelding som<br/>- er kodet som tekst<br/>- identifiserer hvilket skjemaelement som er tomt<br/>- ikke inneholder informasjon om hva som er feil"
+				}
+			}
+		}
+	]
 }

--- a/Testreglar/3.3.1/Nett/331aNett2025.json
+++ b/Testreglar/3.3.1/Nett/331aNett2025.json
@@ -1,0 +1,169 @@
+{
+    "namn": "Nett-3.3.1a Skjema gir feilmelding hvis tomme obligatoriske skjemafelt blir oppdaget automatisk 2025",
+    "id": "331aNett2025",
+    "testlabId": 607,
+    "versjon": "1.0",
+    "type": "Nett",
+    "spraak": "nb",
+    "kravTilSamsvar": "<p>Dersom det blir oppdaget automatisk at obligatoriske skjemaelement ikke er fylt ut, er følgende tre punkter oppfylt:</p><ul><li>Skjemaelementet der feilen oppstod identifiseres.</li><li>Brukeren får en presis tekstlig beskrivelse av feilen.</li><li>Feilmeldingen er kodet som tekst.</li></ul>",
+    "side": "2.1",
+    "element": "3.1",
+    "steg": [
+        {
+            "stegnr": "2.1",
+            "spm": "Hvilken side tester du?",
+            "ht": "<p>Angi URL eller side-ID.</p>",
+            "type": "tekst",
+            "label": "URL/Side-ID:",
+            "datalist": "Sideutvalg",
+            "oblig": true,
+            "ruting": {
+                "alle": {
+                    "type": "gaaTil",
+                    "steg": "2.2"
+                }
+            }
+        },
+        {
+            "stegnr": "2.2",
+            "spm": "Har testsiden skjema?",
+            "ht": "",
+            "type": "jaNei",
+            "ruting": {
+                "ja": {
+                    "type": "gaaTil",
+                    "steg": "2.3"
+                },
+                "nei": {
+                    "type": "ikkjeForekomst",
+                    "utfall": "Testsiden har ikke skjema."
+                }
+            }
+        },
+        {
+            "stegnr": "2.3",
+            "spm": "Hvilket skjema tester du?",
+            "ht": "<ul><li>beskriv skjema</li><li>beskriv plassering</li></ul><p><strong>Merk:</strong></p><ul><li>Hvis skjema inngår i en prosess, skal du også beskrive prosessen.</li><li>Hvis det gjelder flere elementer, registrerer du ett og ett.</li></ul>",
+            "type": "tekst",
+            "label": "Skjema/prosess:",
+            "multilinje": true,
+            "oblig": true,
+            "ruting": {
+                "alle": {
+                    "type": "gaaTil",
+                    "steg": "2.4"
+                }
+            }
+        },
+        {
+            "stegnr": "2.4",
+            "spm": "Oppdager skjemaet automatisk at obligatoriske skjemaelement er tomme?",
+            "ht": "<ul><li>Ikke fyll ut informasjon i skjemaet (tomt skjema), eller</li><li>la alle obligatoriske skjemaelementer stå tomme, eller</li><li>fjern forhåndsutfylt informasjon (hvis mulig):<ul><li>Forhåndsutfylt informasjon betyr at det allerede står inndata i skjemaet når testsiden er lastet inn.</li><li>For eksempel informasjon hentet fra folkeregisteret som personnummer, fornavn, etternavn og adresse. </li></ul></li><li>Fullfør, send inn eller gå videre i skjemaet, for å sjekke om tomme obligatoriske skjemaelementer blir oppdaget automatisk.</li></ul><p><strong>Merk: </strong></p><ul><li>Begrepet \"oppdages automatisk\" betyr at skjemaet er satt opp slik at det selv oppdager når det mangler nødvendig informasjon i obligatoriske elementer i skjemaet. For eksempel med bruk av attributtene<code> required </code>eller <code>aria-required=\"true\"</code>.</li><li>Skjema der knappen for å gå videre eller fullføre er deaktivert, skal testes.<ul><li>Et deaktivert skjemaelement for å gå videre eller fullføre skjemaet, som blir aktivt når brukeren fyller ut rett informasjon, indikerer at brukeren har utelatt inndata som nettsiden krever, og at dette oppdages automatisk, uten at brukeren er involvert.</li></ul></li></ul>",
+            "type": "jaNei",
+            "ruting": {
+                "nei": {
+                    "type": "ikkjeForekomst",
+                    "utfall": "Skjema oppdager ikke automatisk at obligatoriske skjemaelementer er tomme.",
+                    "element": "2.3"
+                },
+                "ja": {
+                    "type": "gaaTil",
+                    "steg": "3.1"
+                }
+            }
+        },
+        {
+            "stegnr": "3.1",
+            "spm": "Hvilket obligatorisk skjemaelement tester du?",
+            "ht": "<ul><li>Beskriv skjemaelementet</li><li>Beskriv plassering</li></ul><p><strong>Merk: </strong>Hvis det gjelder flere elementer, registrerer du ett og ett.</p>",
+            "type": "tekst",
+            "label": "Skjemaelement:",
+            "multilinje": true,
+            "oblig": true,
+            "ruting": {
+                "alle": {
+                    "type": "gaaTil",
+                    "steg": "3.2"
+                }
+            }
+        },
+        {
+            "stegnr": "3.2",
+            "spm": "Får du en tekstlig feilmelding?",
+            "ht": "<p>Feilmeldingen kan for eksempel vises</p><ul><li>i et modalvindu</li><li>i ledeteksten til skjemaelementet</li><li>øverst på siden</li><li>når du navigerer i skjemaet</li></ul><p><strong>Merk:</strong> Feilmeldingen må være tekstlig, og det er ikke tilstrekkelig å identifisere feilen med et symbol, endret farge, visuell plassering, deaktivert innsendingsknapp eller lignende ikke-tekstlige indikatorer.</p>",
+            "type": "jaNei",
+            "kilde": [
+                "G83"
+            ],
+            "ruting": {
+                "ja": {
+                    "type": "gaaTil",
+                    "steg": "3.3"
+                },
+                "nei": {
+                    "type": "avslutt",
+                    "fasit": "Nei",
+                    "utfall": "Tomme obligatoriske skjemaelement, som blir oppdaget automatisk, får ikke tekstlig feilmelding."
+                }
+            }
+        },
+        {
+            "stegnr": "3.3",
+            "spm": "Er feilmeldingen kodet som tekst?",
+            "ht": "<ul><li>Prøv å markere teksten med mus eller tastatur, eller bruk kodeverktøyet i nettleseren for å sjekke om teksten er kodet som tekst.</li></ul><p><strong>Merk: </strong>Dersom skjemaelementet har attributtet <code>\"required\"</code> eller <code>aria-required=\"true\"</code>, kommer det fram en melding i nettleseren. Denne meldingen er kodet som tekst.</p>",
+            "type": "jaNei",
+            "ruting": {
+                "ja": {
+                    "type": "gaaTil",
+                    "steg": "3.4"
+                },
+                "nei": {
+                    "type": "avslutt",
+                    "fasit": "Nei",
+                    "utfall": "Tomme obligatoriske skjemaelement, som blir oppdaget automatisk, får feilmelding, men den er ikke kodet som tekst."
+                }
+            }
+        },
+        {
+            "stegnr": "3.4",
+            "spm": "Inneholder feilmeldingen tekst som identifiserer hvilket skjemaelement som er tomt?",
+            "ht": "",
+            "type": "jaNei",
+            "kilde": [
+                "G83"
+            ],
+            "ruting": {
+                "ja": {
+                    "type": "gaaTil",
+                    "steg": "3.5"
+                },
+                "nei": {
+                    "type": "avslutt",
+                    "fasit": "Nei",
+                    "utfall": "Tomme obligatoriske skjemaelement, som blir oppdaget automatisk får feilmelding som er kodet som tekst, men identifiserer ikke hvilket skjemaelement som er tomt."
+                }
+            }
+        },
+        {
+            "stegnr": "3.5",
+            "spm": "Inneholder feilmeldingen informasjon om hva som er feil?",
+            "ht": "<p>For eksempel:</p><ul><li>«Fornavn må fylles ut».</li></ul><p><strong>Merk:</strong> Krav om at feilmeldingen skal inneholde forslag til hvordan feil skal rettes, er omfattet av suksesskriterium 3.3.3.</p>",
+            "type": "jaNei",
+            "kilde": [
+                "G83"
+            ],
+            "ruting": {
+                "ja": {
+                    "type": "avslutt",
+                    "fasit": "Ja",
+                    "utfall": "Tomme obligatoriske skjemaelement, som blir oppdaget automatisk, får feilmelding som<br/>- er kodet som tekst<br/>- identifiserer hvilket skjemaelement som er tomt<br/>- inneholder informasjon om hva som er feil"
+                },
+                "nei": {
+                    "type": "avslutt",
+                    "fasit": "Nei",
+                    "utfall": "Tomme obligatoriske skjemaelement, som blir oppdaget automatisk, får feilmelding som<br/>- er kodet som tekst<br/>- identifiserer hvilket skjemaelement som er tomt<br/>- inneholder ikke informasjon om hva som er feil"
+                }
+            }
+        }
+    ]
+}


### PR DESCRIPTION
…t blir oppdaget automatisk 2025

Krav til samsvar: Rettet skrivefeil til:
Dersom det blir oppdaget automatisk at obligatoriske skjemaelement ikke er fylt ut, er følgende tre punkter oppfylt: •	Skjemaelementet der feilen oppstod identifiseres. •	Brukeren får en presis tekstlig beskrivelse av feilen. •	Feilmeldingen er kodet som tekst.

Tatt vekk skjemaelement fra utfall og spørsmål
Tatt vekk pdf word osv. vi tester allerede nett så det er ikke vits å h adobbelt opp. 3.2 endret til: Feilmeldingen kan for eksempel vises •	i et modalvindu
•	i ledeteksten til skjemaelement
•	øverst på siden
•	når du navigerer i skjemaet
Merk: feilmeldingen må være tekstlig, og det er ikke tilstrekkelig å identifisere feilen med et symbol, endret farge, visuell plassering, deaktivert innsendingsknapp eller lignende ikke-tekstlige indikatorer. •	3.3 Prøv å markere teksten med mus eller tastatur, eller bruk kodeverktøyet i nettleseren for å sjekke om teksten er kodet som tekst. Merk: Dersom skjemaelementet har attributtet "required" eller aria-required="true", kommer det fram en melding i nettleseren. Denne meldingen er kodet som tekst. Forenklet for lesebarhet.
Utfall for 3.3 endres til: "Tomme obligatoriske skjemaelement, som blir oppdaget automatisk, får feilmelding, men den er ikke kodet som tekst." }
		"utfall": "Tomme obligatoriske skjemaelement, som blir oppdaget automatisk, får feilmelding som ikke identifiserer hvor feilen er oppstått." Endret til 		"utfall": "Tomme obligatoriske skjemaelement, som blir oppdaget automatisk får feilmelding som er kodet som tekst, men identifiserer ikke hvilket skjemaelement som er tomt" for å standardisere utfallene . Knyttet opp mot spørsmål
Endret spørsmål i 3.5 til Inneholder feilmeldingen informasjon om hva som er feil? For klarspråk Endret utfall for klarspråk: {
	"ja": {
		"type": "avslutt",
		"fasit": "Ja",
		"utfall": "Tomme obligatoriske skjemaelement, som blir oppdaget automatisk, får feilmelding som:<br/>- er kodet som tekst<br/>- identifiserer hvilket skjemaelement som er tomt<br/>- inneholder informasjon om hva som er feil"
	},
	"nei": {
		"type": "avslutt",
		"fasit": "Nei",
		"utfall": "Tomme obligatoriske skjemaelement, som blir oppdaget automatisk, får feilmelding som:<br/>- er kodet som tekst<br/>- identifiserer hvilket skjemaelement som er tomt<br/>- inneholder ikke informasjon om hva som er feil"
	}