### PR TITLE
Fix ruting og oppdatert test

### DIFF
--- a/Testreglar/3.3.1/App/app-3.3.1a-2022.json
+++ b/Testreglar/3.3.1/App/app-3.3.1a-2022.json
@@ -118,7 +118,7 @@
 			"ruting": {
 				"ja": {
 					"type": "gaaTil",
-					"steg": "3.5"
+					"steg": "3.4"
 				},
 				"nei": {
 					"type": "avslutt",
@@ -128,7 +128,7 @@
 			}
 		},
 		{
-			"stegnr": "3.5",
+			"stegnr": "3.4",
 			"spm": "Inneheld feilmeldinga tekst som beskriv feilen?",
 			"ht": "Feilmeldinga gir informasjon om kva feilen består i, slik at brukaren kan finne ut kva som har gått feil, for eksempel \"Fornavn må fyllast ut\". Det er ikkje krav om at feilmeldinga skal innehalde forslag til korleis feil skal rettast. Dette er omfatta av suksesskriterium 3.3.3.",
 			"type": "jaNei",

--- a/Testreglar/3.3.4/Nett/3.3.4b.json
+++ b/Testreglar/3.3.4/Nett/3.3.4b.json
@@ -166,7 +166,7 @@
 			"ruting": {
 				"ja": {
 					"type": "gaaTil",
-					"steg": "3.11"
+					"steg": "3.8"
 				},
 				"nei": {
 					"type": "avslutt",
@@ -176,19 +176,19 @@
 			}
 		},
 		{
-			"stegnr": "3.11",
+			"stegnr": "3.8",
 			"spm": "Angre sletting.",
 			"ht": "Bruk mekanismen, eller følg ei eventuell rutine for å angre sletting.",
 			"type": "instruksjon",
 			"ruting": {
 				"alle": {
 					"type": "gaaTil",
-					"steg": "3.12"
+					"steg": "3.9"
 				}
 			}
 		},
 		{
-			"stegnr": "3.12",
+			"stegnr": "3.9",
 			"spm": "Vart informasjonen gjenoppretta?",
 			"ht": "Kontroller at du fikk gjenskapt same informasjon som du sletta i utgangspunktet.",
 			"type": "jaNei",


### PR DESCRIPTION
Retta ruting i : 

- [app-3.3.1a-2022](https://github.com/TilsynForUniversellUtforming/testreglar-wcag-2.x/compare/testbranch?expand=1#diff-2497b34fce4cd8ee65816e731638d1b40f27d4d32e2610574371eedb05ce3ffc)
- [3.3.4b](https://github.com/TilsynForUniversellUtforming/testreglar-wcag-2.x/compare/testbranch?expand=1#diff-d2c4e4eb2b30d7f0e011f01a35671395585937c32897c66f363dba830391491d)

Oppdatert test for å sjekke etter at de ikke blir "hoppet" over steg.nr


