### PR TITLE
Nett-3.3.1b Skjema gir feilmelding hvis feil inndata blir oppdaget au…

### DIFF
--- a/Testreglar/3.3.1/Nett/331bNett2025.json
+++ b/Testreglar/3.3.1/Nett/331bNett2025.json
@@ -1,0 +1,192 @@
+{
+    "namn": "Nett-3.3.1b Skjema gir feilmelding hvis feil inndata blir oppdaget automatisk 2025",
+    "id": "331bNett2025",
+    "testlabId": 609,
+    "versjon": "1.0",
+    "type": "Nett",
+    "spraak": "nb",
+    "kravTilSamsvar": "<p>For skjemaelementer der inndatafeil blir oppdaget automatisk, er følgende fire punkter oppfylt:</p><ul><li>Skjemaelementet der feilen oppstod identifiseres.</li><li>Brukeren får en presis tekstlig beskrivelse av feilen.</li><li>Feilmeldingen er kodet som tekst.</li><li>Informasjonen blir liggende i skjemaet, med mindre informasjonen er knyttet til personvern eller sikkerhet.</li></ul>",
+    "side": "2.1",
+    "element": "3.1",
+    "steg": [
+        {
+            "stegnr": "2.1",
+            "spm": "Hvilken side tester du?",
+            "ht": "<p>Angi URL eller side-ID.</p>",
+            "type": "tekst",
+            "label": "URL/Side:",
+            "datalist": "Sideutvalg",
+            "oblig": true,
+            "ruting": {
+                "alle": {
+                    "type": "gaaTil",
+                    "steg": "2.2"
+                }
+            }
+        },
+        {
+            "stegnr": "2.2",
+            "spm": "Har testsiden skjema?",
+            "ht": "",
+            "type": "jaNei",
+            "ruting": {
+                "ja": {
+                    "type": "gaaTil",
+                    "steg": "2.3"
+                },
+                "nei": {
+                    "type": "ikkjeForekomst",
+                    "utfall": "Testsiden har ikke skjema."
+                }
+            }
+        },
+        {
+            "stegnr": "2.3",
+            "spm": "Hvilket skjema tester du?",
+            "ht": "<ul><li>beskriv skjema</li><li>beskriv plassering</li></ul><p><strong>Merk: </strong></p><ul><li>Hvis skjema inngår i en prosess, skal du også beskrive prosessen.</li><li>Hvis det er flere skjemaer på siden, registrerer du ett og ett.</li></ul>",
+            "type": "tekst",
+            "label": "Skjema/prosess:",
+            "multilinje": true,
+            "oblig": true,
+            "ruting": {
+                "alle": {
+                    "type": "gaaTil",
+                    "steg": "2.4"
+                }
+            }
+        },
+        {
+            "stegnr": "2.4",
+            "spm": "Oppdager skjemaet automatisk at utfylt inndata har feil format eller verdi?",
+            "ht": "<ul><li>Legg inn feil inndata i alle skjemaelement, eller</li><li>endre forhåndsutfylt informasjon til feil format eller verdi på inndata der det er mulig:<br><ul><li>Forhåndsutfylt informasjon betyr at det allerede står inndata i skjemaet når testsiden er lastet inn.</li><li>For eksempel informasjon hentet fra folkeregisteret som personnummer, fornavn, etternavn og adresse.</li></ul></li><li>Fullfør, send inn eller gå videre i skjemaet, for å sjekke om feil format eller verdi på inndata blir oppdaget automatisk.</li></ul><p><strong>Merk:</strong> </p><ul><li>Skjema der knappen for å gå videre eller fullføre er deaktivert, skal testes.<ul><li>Et deaktivert skjemaelement for å gå videre eller fullføre skjemaet, som blir aktivt når brukeren fyller ut rett informasjon, indikerer at brukeren har utelatt inndata som nettsiden krever, og at dette oppdages automatisk, uten at brukeren er involvert.</li></ul></li><li>Begrepet \"oppdages automatisk\" betyr at skjemaet er satt opp slik at det selv oppdager når inndata er lagt inn med feil format eller verdi. </li><li>Eksempler på feil inndata er postnummer med bokstaver, navn som inneholder tall eller spesialtegn, ugyldige formater for e-post, dato eller telefonnummer, samt data utenfor grenseverdier, som måned 14 i en dato.</li></ul>",
+            "type": "jaNei",
+            "ruting": {
+                "nei": {
+                    "type": "ikkjeForekomst",
+                    "utfall": "Skjema oppdager ikke automatisk at utfylt inndata har feil format eller verdi.",
+                    "element": "2.3"
+                },
+                "ja": {
+                    "type": "gaaTil",
+                    "steg": "3.1"
+                }
+            }
+        },
+        {
+            "stegnr": "3.1",
+            "spm": "Hvilket skjemaelement tester du?",
+            "ht": "<ul><li>beskriv skjemaelementet</li><li>beskriv plassering</li></ul><p><strong>Merk:</strong> Hvis det gjelder flere elementer, registrerer du ett og ett.</p>",
+            "type": "tekst",
+            "label": "Skjemaelement:",
+            "multilinje": true,
+            "oblig": true,
+            "ruting": {
+                "alle": {
+                    "type": "gaaTil",
+                    "steg": "3.2"
+                }
+            }
+        },
+        {
+            "stegnr": "3.2",
+            "spm": "Blir informasjonen du har fylt ut, som skal bli liggende, liggende i skjemaelementet? ",
+            "ht": "<p><strong>Merk:</strong></p><ul><li>Det er ok at feil inndata blir korrigert automatisk.</li><li>Hovedregelen er at informasjon som er fylt ut skal bli liggende i skjemaet, selv om det blir oppdaget inndatafeil.</li><li>Unntaket er dersom informasjonen er knyttet til personvern eller sikkerhet (sensitiv informasjon). </li></ul>",
+            "type": "jaNei",
+            "kilde": [
+                "G84",
+                "G85"
+            ],
+            "ruting": {
+                "ja": {
+                    "type": "gaaTil",
+                    "steg": "3.3"
+                },
+                "nei": {
+                    "type": "avslutt",
+                    "fasit": "Nei",
+                    "utfall": "I skjemaelement der inndatafeil blir oppdaget automatisk, forsvinner inndata fra skjemaelementet."
+                }
+            }
+        },
+        {
+            "stegnr": "3.3",
+            "spm": "Får du en tekstlig feilmelding?",
+            "ht": "<p>Feilmeldingen kan for eksempel vises</p><ul><li>i et modalvindu</li><li>i ledeteksten til skjemaelementet</li><li>øverst på siden</li><li>når du navigerer i skjemaet</li></ul><p><strong>Merk:</strong> Feilmeldingen må være tekstlig, og det er ikke tilstrekkelig å identifisere feilen med et symbol, endret farge, visuell plassering, deaktivert innsendingsknapp eller lignende ikke-tekstlige indikatorer.</p>",
+            "type": "jaNei",
+            "kilde": [
+                "G84",
+                "G85"
+            ],
+            "ruting": {
+                "ja": {
+                    "type": "gaaTil",
+                    "steg": "3.4"
+                },
+                "nei": {
+                    "type": "avslutt",
+                    "fasit": "Nei",
+                    "utfall": "Skjemaelement der inndatafeil blir oppdaget automatisk, får ikke tekstlig feilmelding."
+                }
+            }
+        },
+        {
+            "stegnr": "3.4",
+            "spm": "Er feilmeldingen kodet som tekst?",
+            "ht": "<ul><li>Prøv å markere teksten med mus eller tastatur, eller bruk kodeverktøyet i nettleseren for å sjekke om teksten er kodet som tekst.</li></ul><p><strong>Merk: </strong>Dersom skjemaelementet har attributtet <code>\"required\"</code> eller <code>aria-required=\"true\"</code>, kommer det fram en melding i nettleseren. Denne meldingen er kodet som tekst.</p>",
+            "type": "jaNei",
+            "ruting": {
+                "ja": {
+                    "type": "gaaTil",
+                    "steg": "3.5"
+                },
+                "nei": {
+                    "type": "avslutt",
+                    "fasit": "Nei",
+                    "utfall": "Skjemaelement der inndatafeil blir oppdaget automatisk, får feilmelding som ikke er kodet som tekst."
+                }
+            }
+        },
+        {
+            "stegnr": "3.5",
+            "spm": "Inneholder feilmeldingen informasjon som identifiserer hvilket skjemaelement som automatisk oppdager inndatafeil?",
+            "ht": "",
+            "type": "jaNei",
+            "kilde": [
+                "G83"
+            ],
+            "ruting": {
+                "ja": {
+                    "type": "gaaTil",
+                    "steg": "3.6"
+                },
+                "nei": {
+                    "type": "avslutt",
+                    "fasit": "Nei",
+                    "utfall": "Skjemaelement der inndatafeil blir oppdaget automatisk, får feilmelding som er kodet som tekst, men identifiserer ikke hvilket skjemaelement som har inndatafeil."
+                }
+            }
+        },
+        {
+            "stegnr": "3.6",
+            "spm": "Inneholder feilmeldingen tekst som beskriver feilen?",
+            "ht": "<p>For eksempel:</p><ul><li>\"Telefonnummer kan ikke inneholde bokstaver\".</li></ul><p><strong>Merk: </strong>Krav om at feilmeldingen skal inneholde forslag til hvordan feil skal rettes, er omfattet av suksesskriterium 3.3.3.</p>",
+            "type": "jaNei",
+            "kilde": [
+                "G84",
+                "G85"
+            ],
+            "ruting": {
+                "ja": {
+                    "type": "avslutt",
+                    "fasit": "Ja",
+                    "utfall": "Skjemaelement der inndatafeil blir oppdaget automatisk, får feilmelding som<br/>- er kodet som tekst<br/>- identifiserer hvilket skjemaelement som har feil inndata<br/>- inneholder informasjon om hva som er feil"
+                },
+                "nei": {
+                    "type": "avslutt",
+                    "fasit": "Nei",
+                    "utfall": "Skjemaelement der inndatafeil blir oppdaget automatisk, får feilmelding som<br/>- er kodet som tekst<br/>- identifiserer hvilket skjemaelement som har feil inndata<br/>- ikke inneholder informasjon om hva som er feil"
+                }
+            }
+        }
+    ]
+}


### PR DESCRIPTION
…tomatisk 2025

3.3.1b nett 2025
Alle steg er forandret som i 3.3.1A nett men for å passe «automatisk oppdagede inndatafelt» fremfor «tomme obligatoriske felt». 2.2 - fjernet “skjemaelement” i spørsmål og utfall. Nytt utfall blir: "Testsiden har ikke skjema. 3.5 - Endret utfall til: "Skjemaelement der inndatafeil blir oppdaget automatisk, får feilmelding som er kodet som tekst, men identifiserer ikke hvilket skjemaelement som har inndatafeil."